### PR TITLE
Refactor MLP output layer.

### DIFF
--- a/deeplay/components/mlp.py
+++ b/deeplay/components/mlp.py
@@ -40,9 +40,9 @@ class MultiLayerPerceptron(DeeplayModule):
     Examples
     --------
     >>> mlp = MultiLayerPerceptron(28 * 28, [128, 128], 10)
-    >>> mlp.input.layer.configure(kernel_size=5)
     >>> mlp.hidden.normalization.configure(nn.BatchNorm1d)
     >>> mlp.output.activation.configure(nn.Softmax)
+    >>> mlp.layer.configure(bias=False)
     >>> mlp.build()
 
 

--- a/deeplay/components/mlp.py
+++ b/deeplay/components/mlp.py
@@ -13,20 +13,20 @@ class MultiLayerPerceptron(DeeplayModule):
     Configurables
     -------------
 
-    - in_features (int): Number of input features. If None, the input shape is inferred from the first forward pass. (Default: None)
-    - hidden_dims (list[int]): Number of hidden units in each layer. (Default: [32, 32])
+    - in_features (int): Number of input features. If None, the input shape is inferred in the first forward pass. (Default: None)
+    - hidden_dims (list[int]): Number of hidden units in each layer.
     - out_features (int): Number of output features. (Default: 1)
     - blocks (template-like): Specification for the blocks of the MLP. (Default: "layer" >> "activation" >> "normalization" >> "dropout")
         - layer (template-like): Specification for the layer of the block. (Default: nn.Linear)
         - activation (template-like): Specification for the activation of the block. (Default: nn.ReLU)
         - normalization (template-like): Specification for the normalization of the block. (Default: nn.Identity)
-        - dropout (template-like): Specification for the dropout of the block. (Default: nn.Identity)
     - out_activation (template-like): Specification for the output activation of the MLP. (Default: nn.Identity)
 
-    Constraints
-    -----------
-    - input shape: (batch_size, ch_in)
-    - output shape: (batch_size, ch_out)
+    Shorthands
+    ----------
+    - `input`: Equivalent to `.blocks[0]`.
+    - `hidden`: Equivalent to `.blocks[:-1]`.
+    - `output`: Equivalent to `.blocks[-1]`.
 
     Evaluation
     ----------
@@ -36,27 +36,16 @@ class MultiLayerPerceptron(DeeplayModule):
 
     Examples
     --------
-    >>> # Using default values
-    >>> mlp = MultiLayerPerceptron(28 * 28, [128], 10)
-    >>> # Customizing output activation
-    >>> mlp = MultiLayerPerceptron(28 * 28, [128], 1, nn.Sigmoid)
-    >>> # Using from_config with custom normalization
-    >>> mlp = MultiLayerPerceptron.from_config(
-    >>>     Config()
-    >>>     .in_features(28 * 28)
-    >>>     .hidden_dims([128])
-    >>>     .out_features(1)
-    >>>     .out_activation(nn.Sigmoid)
-    >>>     .blocks[0].normalization(nn.BatchNorm1d, num_features=128)
-    >>> )
+    >>> mlp = MultiLayerPerceptron(28 * 28, [128, 128], 10)
+    >>> mlp.input.layer.configure(kernel_size=5)
+    >>> mlp.hidden.normalization.configure(nn.BatchNorm1d)
+    >>> mlp.output.activation.configure(nn.Softmax)
+    >>> mlp.build()
+
 
     Return Values
     -------------
     The forward method returns the processed tensor.
-
-    Additional Notes
-    ----------------
-    The `Config` and `Layer` classes are used for configuring the blocks of the MLP. For more details refer to [Config Documentation](#) and [Layer Documentation](#).
 
     """
 
@@ -64,21 +53,20 @@ class MultiLayerPerceptron(DeeplayModule):
     hidden_dims: Sequence[Optional[int]]
     out_features: int
     blocks: LayerList[LayerActivationNormalizationBlock]
-    out_layer: LayerActivationNormalizationBlock
 
     @property
     def input(self):
-        """Return the input layer of the network."""
+        """Return the input layer of the network. Equivalent to `.blocks[0]`."""
         return self.blocks[0]
 
     @property
     def hidden(self):
-        """Return the hidden layers of the network (inclusive first, exclusive last)."""
+        """Return the hidden layers of the network. Equivalent to `.blocks[:-1]`"""
         return self.blocks[:-1]
 
     @property
     def output(self):
-        """Return the last layer of the network."""
+        """Return the last layer of the network. Equivalent to `.blocks[-1]`."""
         return self.blocks[-1]
 
     def __init__(
@@ -135,21 +123,9 @@ class MultiLayerPerceptron(DeeplayModule):
         self,
         /,
         in_features: int | None = None,
-        hidden_dims: List[int] | None = None,
+        hidden_features: List[int] | None = None,
         out_features: int | None = None,
         out_activation: Type[nn.Module] | nn.Module | None = None,
-    ) -> None:
-        ...
-
-    @overload
-    def configure(
-        self,
-        name: Literal["out_layer", "blocks"],
-        order: Optional[Sequence[str]] = None,
-        layer: Optional[Type[nn.Module]] = None,
-        activation: Optional[Type[nn.Module]] = None,
-        normalization: Optional[Type[nn.Module]] = None,
-        **kwargs: Any,
     ) -> None:
         ...
 

--- a/deeplay/components/mlp.py
+++ b/deeplay/components/mlp.py
@@ -67,7 +67,17 @@ class MultiLayerPerceptron(DeeplayModule):
     out_layer: LayerActivationNormalizationBlock
 
     @property
-    def out_layer(self):
+    def input(self):
+        """Return the input layer of the network."""
+        return self.blocks[0]
+
+    @property
+    def hidden(self):
+        """Return the hidden layers of the network (inclusive first, exclusive last)."""
+        return self.blocks[:-1]
+
+    @property
+    def output(self):
         """Return the last layer of the network."""
         return self.blocks[-1]
 

--- a/deeplay/components/mlp.py
+++ b/deeplay/components/mlp.py
@@ -27,6 +27,9 @@ class MultiLayerPerceptron(DeeplayModule):
     - `input`: Equivalent to `.blocks[0]`.
     - `hidden`: Equivalent to `.blocks[:-1]`.
     - `output`: Equivalent to `.blocks[-1]`.
+    - `layer`: Equivalent to `.blocks.layer`.
+    - `activation`: Equivalent to `.blocks.activation`.
+    - `normalization`: Equivalent to `.blocks.normalization`.
 
     Evaluation
     ----------
@@ -68,6 +71,21 @@ class MultiLayerPerceptron(DeeplayModule):
     def output(self):
         """Return the last layer of the network. Equivalent to `.blocks[-1]`."""
         return self.blocks[-1]
+
+    @property
+    def layer(self) -> LayerList[Layer]:
+        """Return the layers of the network. Equivalent to `.blocks.layer`."""
+        return self.blocks.layer
+
+    @property
+    def activation(self) -> LayerList[Layer]:
+        """Return the activations of the network. Equivalent to `.blocks.activation`."""
+        return self.blocks.activation
+
+    @property
+    def normalization(self) -> LayerList[Layer]:
+        """Return the normalizations of the network. Equivalent to `.blocks.normalization`."""
+        return self.blocks.normalization
 
     def __init__(
         self,
@@ -115,7 +133,7 @@ class MultiLayerPerceptron(DeeplayModule):
                     # We can give num_features as an argument to nn.Identity
                     # because it is ignored. This means that users do not have
                     # to specify the number of features for nn.Identity.
-                    Layer(nn.Identity, num_features=out_features),
+                    Layer(nn.Identity, num_features=f_out),
                 )
             )
 

--- a/deeplay/components/mlp.py
+++ b/deeplay/components/mlp.py
@@ -66,6 +66,11 @@ class MultiLayerPerceptron(DeeplayModule):
     blocks: LayerList[LayerActivationNormalizationBlock]
     out_layer: LayerActivationNormalizationBlock
 
+    @property
+    def out_layer(self):
+        """Return the last layer of the network."""
+        return self.blocks[-1]
+
     def __init__(
         self,
         in_features: Optional[int],
@@ -101,17 +106,18 @@ class MultiLayerPerceptron(DeeplayModule):
                 )
             )
 
-        self.out_layer = LayerActivationNormalizationBlock(
-            Layer(nn.Linear, self.hidden_dims[-1], self.out_features),
-            out_activation,
-            Layer(nn.Identity, num_features=self.out_features),
+        self.blocks.append(
+            LayerActivationNormalizationBlock(
+                Layer(nn.Linear, self.hidden_dims[-1], self.out_features),
+                out_activation,
+                Layer(nn.Identity, num_features=self.out_features),
+            )
         )
 
     def forward(self, x):
         x = nn.Flatten()(x)
         for block in self.blocks:
             x = block(x)
-        x = self.out_layer(x)
         return x
 
     @overload

--- a/deeplay/components/mlp.py
+++ b/deeplay/components/mlp.py
@@ -82,10 +82,25 @@ class MultiLayerPerceptron(DeeplayModule):
         self.hidden_features = hidden_features
         self.out_features = out_features
 
+        if out_features <= 0:
+            raise ValueError(
+                f"Number of output features must be positive, got {out_features}"
+            )
+
+        if in_features is not None and in_features <= 0:
+            raise ValueError(f"in_channels must be positive, got {in_features}")
+
+        if any(h <= 0 for h in hidden_features):
+            raise ValueError(
+                f"all hidden_channels must be positive, got {hidden_features}"
+            )
+
         if out_activation is None:
             out_activation = Layer(nn.Identity)
         elif isinstance(out_activation, type) and issubclass(out_activation, nn.Module):
             out_activation = Layer(out_activation)
+
+        f_out = in_features
 
         self.blocks = LayerList()
         for i, f_out in enumerate(self.hidden_features):
@@ -106,7 +121,7 @@ class MultiLayerPerceptron(DeeplayModule):
 
         self.blocks.append(
             LayerActivationNormalizationBlock(
-                Layer(nn.Linear, self.hidden_features[-1], self.out_features),
+                Layer(nn.Linear, f_out, self.out_features),
                 out_activation,
                 Layer(nn.Identity, num_features=self.out_features),
             )

--- a/deeplay/components/mlp.py
+++ b/deeplay/components/mlp.py
@@ -14,7 +14,7 @@ class MultiLayerPerceptron(DeeplayModule):
     -------------
 
     - in_features (int): Number of input features. If None, the input shape is inferred in the first forward pass. (Default: None)
-    - hidden_dims (list[int]): Number of hidden units in each layer.
+    - hidden_features (list[int]): Number of hidden units in each layer.
     - out_features (int): Number of output features. (Default: 1)
     - blocks (template-like): Specification for the blocks of the MLP. (Default: "layer" >> "activation" >> "normalization" >> "dropout")
         - layer (template-like): Specification for the layer of the block. (Default: nn.Linear)
@@ -50,7 +50,7 @@ class MultiLayerPerceptron(DeeplayModule):
     """
 
     in_features: Optional[int]
-    hidden_dims: Sequence[Optional[int]]
+    hidden_features: Sequence[Optional[int]]
     out_features: int
     blocks: LayerList[LayerActivationNormalizationBlock]
 
@@ -79,7 +79,7 @@ class MultiLayerPerceptron(DeeplayModule):
         super().__init__()
 
         self.in_features = in_features
-        self.hidden_dims = hidden_features
+        self.hidden_features = hidden_features
         self.out_features = out_features
 
         if out_activation is None:
@@ -88,8 +88,8 @@ class MultiLayerPerceptron(DeeplayModule):
             out_activation = Layer(out_activation)
 
         self.blocks = LayerList()
-        for i, f_out in enumerate(self.hidden_dims):
-            f_in = self.in_features if i == 0 else self.hidden_dims[i - 1]
+        for i, f_out in enumerate(self.hidden_features):
+            f_in = self.in_features if i == 0 else self.hidden_features[i - 1]
 
             self.blocks.append(
                 LayerActivationNormalizationBlock(
@@ -106,7 +106,7 @@ class MultiLayerPerceptron(DeeplayModule):
 
         self.blocks.append(
             LayerActivationNormalizationBlock(
-                Layer(nn.Linear, self.hidden_dims[-1], self.out_features),
+                Layer(nn.Linear, self.hidden_features[-1], self.out_features),
                 out_activation,
                 Layer(nn.Identity, num_features=self.out_features),
             )

--- a/deeplay/module.py
+++ b/deeplay/module.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Tuple, List
 
 import torch.nn as nn
 
@@ -76,7 +76,7 @@ class DeeplayModule(nn.Module, metaclass=ExtendedConstructorMeta):
     _is_constructing: bool = False
     _is_building: bool = False
 
-    __extra_configurables__: list[str] = []
+    __extra_configurables__: Liststr] = []
 
     _args: tuple
     _kwargs: dict

--- a/deeplay/tests/test_mlp.py
+++ b/deeplay/tests/test_mlp.py
@@ -70,3 +70,40 @@ class TestComponentMLP(unittest.TestCase):
         self.assertEqual(len(mlp.blocks), 1)
         self.assertEqual(mlp.blocks[0].layer.in_features, 2)
         self.assertEqual(mlp.blocks[0].layer.out_features, 3)
+
+    def test_configure_layers(self):
+        mlp = MultiLayerPerceptron(2, [4, 3, 5], 3)
+        mlp.layer.configure(bias=False)
+        mlp.build()
+        self.assertEqual(len(mlp.blocks), 4)
+        for idx, block in enumerate(mlp.blocks):
+            self.assertFalse(block.layer.bias)
+
+    def test_configure_activation(self):
+        mlp = MultiLayerPerceptron(2, [4, 3, 5], 3)
+        mlp.activation.configure(nn.Sigmoid)
+        mlp.build()
+        self.assertEqual(len(mlp.blocks), 4)
+        for idx, block in enumerate(mlp.blocks):
+            self.assertIsInstance(block.activation, nn.Sigmoid)
+
+    def test_configure_activation_with_argument(self):
+        mlp = MultiLayerPerceptron(2, [4, 3, 5], 3)
+        mlp.activation.configure(nn.Softmax, dim=4)
+        mlp.build()
+        self.assertEqual(len(mlp.blocks), 4)
+        for idx, block in enumerate(mlp.blocks):
+            self.assertIsInstance(block.activation, nn.Softmax)
+            self.assertEqual(block.activation.dim, 4)
+
+    def test_configure_normalization(self):
+        mlp = MultiLayerPerceptron(2, [4, 3, 5], 3)
+        mlp.normalization.configure(nn.BatchNorm1d)
+        mlp.build()
+        self.assertEqual(len(mlp.blocks), 4)
+        for idx, block in enumerate(mlp.blocks):
+            self.assertIsInstance(block.normalization, nn.BatchNorm1d)
+
+        x = torch.randn(2, 2)
+        y = mlp(x)
+        self.assertEqual(y.shape, (2, 3))

--- a/deeplay/tests/test_mlp.py
+++ b/deeplay/tests/test_mlp.py
@@ -63,3 +63,10 @@ class TestComponentMLP(unittest.TestCase):
         mlp.build()
         self.assertEqual(len(mlp.blocks), 2)
         self.assertIsInstance(mlp.output.activation, nn.Sigmoid)
+
+    def test_no_hidden_layers(self):
+        mlp = MultiLayerPerceptron(2, [], 3)
+        mlp.build()
+        self.assertEqual(len(mlp.blocks), 1)
+        self.assertEqual(mlp.blocks[0].layer.in_features, 2)
+        self.assertEqual(mlp.blocks[0].layer.out_features, 3)

--- a/deeplay/tests/test_mlp.py
+++ b/deeplay/tests/test_mlp.py
@@ -10,13 +10,13 @@ class TestComponentMLP(unittest.TestCase):
     def test_mlp_defaults(self):
         mlp = MultiLayerPerceptron(2, [4], 3)
         mlp.build()
-        self.assertEqual(len(mlp.blocks), 1)
+        self.assertEqual(len(mlp.blocks), 2)
 
         self.assertEqual(mlp.blocks[0].layer.in_features, 2)
         self.assertEqual(mlp.blocks[0].layer.out_features, 4)
 
-        self.assertEqual(mlp.out_layer.layer.in_features, 4)
-        self.assertEqual(mlp.out_layer.layer.out_features, 3)
+        self.assertEqual(mlp.output.layer.in_features, 4)
+        self.assertEqual(mlp.output.layer.out_features, 3)
 
         # test on a batch of 2
         x = torch.randn(2, 2)
@@ -25,12 +25,12 @@ class TestComponentMLP(unittest.TestCase):
 
     def test_mlp_lazy_input(self):
         mlp = MultiLayerPerceptron(None, [4], 3).build()
-        self.assertEqual(len(mlp.blocks), 1)
+        self.assertEqual(len(mlp.blocks), 2)
 
         self.assertEqual(mlp.blocks[0].layer.in_features, 0)
         self.assertEqual(mlp.blocks[0].layer.out_features, 4)
-        self.assertEqual(mlp.out_layer.layer.in_features, 4)
-        self.assertEqual(mlp.out_layer.layer.out_features, 3)
+        self.assertEqual(mlp.output.layer.in_features, 4)
+        self.assertEqual(mlp.output.layer.out_features, 3)
 
         # test on a batch of 2
         x = torch.randn(2, 2)
@@ -41,25 +41,25 @@ class TestComponentMLP(unittest.TestCase):
         mlp = MultiLayerPerceptron(2, [4], 3)
         mlp.configure(hidden_features=[4, 4])
         mlp.build()
-        self.assertEqual(len(mlp.blocks), 2)
+        self.assertEqual(len(mlp.blocks), 3)
 
     def test_change_activation(self):
         mlp = MultiLayerPerceptron(2, [4], 3)
         mlp.configure(out_activation=nn.Sigmoid)
         mlp.build()
-        self.assertEqual(len(mlp.blocks), 1)
-        self.assertIsInstance(mlp.out_layer.activation, nn.Sigmoid)
+        self.assertEqual(len(mlp.blocks), 2)
+        self.assertIsInstance(mlp.output.activation, nn.Sigmoid)
 
     def test_change_out_activation_Layer(self):
         mlp = MultiLayerPerceptron(2, [4], 3)
         mlp.configure(out_activation=Layer(nn.Sigmoid))
         mlp.build()
-        self.assertEqual(len(mlp.blocks), 1)
-        self.assertIsInstance(mlp.out_layer.activation, nn.Sigmoid)
+        self.assertEqual(len(mlp.blocks), 2)
+        self.assertIsInstance(mlp.output.activation, nn.Sigmoid)
 
     def test_change_out_activation_instance(self):
         mlp = MultiLayerPerceptron(2, [4], 3)
         mlp.configure(out_activation=nn.Sigmoid())
         mlp.build()
-        self.assertEqual(len(mlp.blocks), 1)
-        self.assertIsInstance(mlp.out_layer.activation, nn.Sigmoid)
+        self.assertEqual(len(mlp.blocks), 2)
+        self.assertIsInstance(mlp.output.activation, nn.Sigmoid)


### PR DESCRIPTION
Instead of having an actual output block, this PR proposes to have all blocks inside of `MultiLayerPerceptron.blocks`.
Additionally, it proposes to add three short-hand properties to more easily access specific blocks. These are `input -> blocks[0]`, `hidden -> blocks[:-1]` and `output -> blocks[-1]`

## How does it currently work?

Currently, the output block of MLP is not a part of `mlp.blocks`. This means it needs to be configured independently of `blocks`.

### Example
Adding normalization:
```
model = MultiLayerPerceptron(728, [32. 32], 10)
model.blocks.normalization.configure(BatchNorm1d)
model.out_layer.normalization.configure(BatchNorm1d)
```

The rationale for this was that it's common to want to treat the output layer differently from internal layers. However, when used as a part of a larger network (which I imagine these fundamental models will often be) this no longer holds.


## What does this change?

Configuring all layers:
```py
model = MultiLayerPerceptron(728, [32. 32], 10)
model.blocks.normalization.configure(BatchNorm1d)
print(model.output.normalization) # BatchNorm1d
```

to not change the output normalization:
```py
model = MultiLayerPerceptron(728, [32. 32], 10)
model.hidden.normalization.configure(BatchNorm1d)
print(model.output.normalization) # Identity
```

Alternative syntax:
```py
model = MultiLayerPerceptron(728, [32. 32], 10)
model.blocks[:-1].normalization.configure(BatchNorm1d)
print(model.output.normalization) # Identity
```

## Drawbacks

It will override the out_activation parameter if configured (by design, but maybe unexpectedly?)
```py
model = MultiLayerPerceptron(728, [32. 32], 10, out_activation=ReLU)
model.blocks.activation.configure(Sigmoid)
print(model.out_layer.activation) # Sigmoid
```

again, this is avoided by indexing `[:-1]` or accessing `.hidden`.

## Scope

I envision the same design to be standard for all unimodal sequential models. Like for example `ConvolutionalNeuralNetwork`.