### PR TITLE
Bm/cnn

### DIFF
--- a/deeplay/applications/classification/binary.py
+++ b/deeplay/applications/classification/binary.py
@@ -11,7 +11,7 @@ import torchmetrics as tm
 from .classifier import Classifier
 
 
-class BinaryClassifier(Classifier):
+class BinaryClassifier(Application):
     model: torch.nn.Module
     loss: torch.nn.Module
     metrics: list

--- a/deeplay/applications/classification/categorical.py
+++ b/deeplay/applications/classification/categorical.py
@@ -11,7 +11,7 @@ import torchmetrics as tm
 from .classifier import Classifier
 
 
-class CategoricalClassifier(Classifier):
+class CategoricalClassifier(Application):
     model: torch.nn.Module
     loss: torch.nn.Module
     metrics: list

--- a/deeplay/applications/classification/multilabel.py
+++ b/deeplay/applications/classification/multilabel.py
@@ -11,7 +11,7 @@ import torchmetrics as tm
 from .classifier import Classifier
 
 
-class MultiLabelClassifier(Classifier):
+class MultiLabelClassifier(Application):
     model: torch.nn.Module
     loss: torch.nn.Module
     metrics: list

--- a/deeplay/blocks/LA.py
+++ b/deeplay/blocks/LA.py
@@ -14,26 +14,26 @@ from ..module import DeeplayModule
 from .sequential import SequentialBlock
 
 
-class LayerActivationBlock(SequentialBlock):
+class LayerAct(SequentialBlock):
     layer: DeeplayModule
-    activation: DeeplayModule
+    act: DeeplayModule
     order: List[str]
 
     def __init__(
         self,
         layer: DeeplayModule,
-        activation: DeeplayModule,
-        order=["layer", "activation"],
+        act: DeeplayModule,
+        order=["layer", "act"],
         **kwargs: DeeplayModule,
     ):
-        super().__init__(layer=layer, activation=activation, order=order, **kwargs)
+        super().__init__(layer=layer, act=act, order=order, **kwargs)
 
     @overload
     def configure(
         self,
         order: Optional[List[str]] = None,
         layer: Optional[DeeplayModule] = None,
-        activation: Optional[DeeplayModule] = None,
+        act: Optional[DeeplayModule] = None,
         **kwargs: DeeplayModule,
     ) -> None:
         ...
@@ -43,7 +43,7 @@ class LayerActivationBlock(SequentialBlock):
         ...
 
     @overload
-    def configure(self, name: Literal["activation"], *args, **kwargs) -> None:
+    def configure(self, name: Literal["act"], *args, **kwargs) -> None:
         ...
 
     @overload

--- a/deeplay/blocks/LA.py
+++ b/deeplay/blocks/LA.py
@@ -14,26 +14,26 @@ from ..module import DeeplayModule
 from .sequential import SequentialBlock
 
 
-class LayerAct(SequentialBlock):
+class LayerActivation(SequentialBlock):
     layer: DeeplayModule
-    act: DeeplayModule
+    activation: DeeplayModule
     order: List[str]
 
     def __init__(
         self,
         layer: DeeplayModule,
-        act: DeeplayModule,
-        order=["layer", "act"],
+        activation: DeeplayModule,
+        order=["layer", "activation"],
         **kwargs: DeeplayModule,
     ):
-        super().__init__(layer=layer, act=act, order=order, **kwargs)
+        super().__init__(layer=layer, activation=activation, order=order, **kwargs)
 
     @overload
     def configure(
         self,
         order: Optional[List[str]] = None,
         layer: Optional[DeeplayModule] = None,
-        act: Optional[DeeplayModule] = None,
+        activation: Optional[DeeplayModule] = None,
         **kwargs: DeeplayModule,
     ) -> None:
         ...
@@ -43,7 +43,7 @@ class LayerAct(SequentialBlock):
         ...
 
     @overload
-    def configure(self, name: Literal["act"], *args, **kwargs) -> None:
+    def configure(self, name: Literal["activation"], *args, **kwargs) -> None:
         ...
 
     @overload

--- a/deeplay/blocks/LAN.py
+++ b/deeplay/blocks/LAN.py
@@ -13,24 +13,24 @@ from ..module import DeeplayModule
 from .sequential import SequentialBlock
 
 
-class LayerActNorm(SequentialBlock):
+class LayerActivationNormalization(SequentialBlock):
     layer: nn.Module
-    act: nn.Module
-    norm: nn.Module
+    activation: nn.Module
+    normalization: nn.Module
     order: List[str]
 
     def __init__(
         self,
         layer: nn.Module,
-        act: nn.Module,
-        norm: nn.Module,
-        order: List[str] = ["layer", "act", "norm"],
+        activation: nn.Module,
+        normalization: nn.Module,
+        order: List[str] = ["layer", "activation", "normalization"],
         **kwargs: nn.Module,
     ):
         super().__init__(
             layer=layer,
-            act=act,
-            norm=norm,
+            activation=activation,
+            normalization=normalization,
             order=order,
             **kwargs,
         )
@@ -44,7 +44,7 @@ class LayerActNorm(SequentialBlock):
         self,
         order: Optional[List[str]],
         layer: Optional[nn.Module],
-        act: Optional[nn.Module],
+        activation: Optional[nn.Module],
         **kwargs: nn.Module,
     ) -> None:
         ...
@@ -54,11 +54,11 @@ class LayerActNorm(SequentialBlock):
         ...
 
     @overload
-    def configure(self, name: Literal["act"], *args, **kwargs) -> None:
+    def configure(self, name: Literal["activation"], *args, **kwargs) -> None:
         ...
 
     @overload
-    def configure(self, name: Literal["norm"], *args, **kwargs) -> None:
+    def configure(self, name: Literal["normalization"], *args, **kwargs) -> None:
         ...
 
     @overload

--- a/deeplay/blocks/LAN.py
+++ b/deeplay/blocks/LAN.py
@@ -13,24 +13,24 @@ from ..module import DeeplayModule
 from .sequential import SequentialBlock
 
 
-class LayerActivationNormalizationBlock(SequentialBlock):
+class LayerActNorm(SequentialBlock):
     layer: nn.Module
-    activation: nn.Module
-    normalization: nn.Module
+    act: nn.Module
+    norm: nn.Module
     order: List[str]
 
     def __init__(
         self,
         layer: nn.Module,
-        activation: nn.Module,
-        normalization: nn.Module,
-        order: List[str] = ["layer", "activation", "normalization"],
+        act: nn.Module,
+        norm: nn.Module,
+        order: List[str] = ["layer", "act", "norm"],
         **kwargs: nn.Module,
     ):
         super().__init__(
             layer=layer,
-            activation=activation,
-            normalization=normalization,
+            act=act,
+            norm=norm,
             order=order,
             **kwargs,
         )
@@ -44,7 +44,7 @@ class LayerActivationNormalizationBlock(SequentialBlock):
         self,
         order: Optional[List[str]],
         layer: Optional[nn.Module],
-        activation: Optional[nn.Module],
+        act: Optional[nn.Module],
         **kwargs: nn.Module,
     ) -> None:
         ...
@@ -54,11 +54,11 @@ class LayerActivationNormalizationBlock(SequentialBlock):
         ...
 
     @overload
-    def configure(self, name: Literal["activation"], *args, **kwargs) -> None:
+    def configure(self, name: Literal["act"], *args, **kwargs) -> None:
         ...
 
     @overload
-    def configure(self, name: Literal["normalization"], *args, **kwargs) -> None:
+    def configure(self, name: Literal["norm"], *args, **kwargs) -> None:
         ...
 
     @overload

--- a/deeplay/blocks/PLAN.py
+++ b/deeplay/blocks/PLAN.py
@@ -11,27 +11,27 @@ import torch.nn as nn
 from .sequential import SequentialBlock
 
 
-class PoolLayerActNorm(SequentialBlock):
+class PoolLayerActivationNormalization(SequentialBlock):
     pool: nn.Module
     layer: nn.Module
-    act: nn.Module
-    norm: nn.Module
+    activation: nn.Module
+    normalization: nn.Module
     order: List[str]
 
     def __init__(
         self,
         pool: nn.Module,
         layer: nn.Module,
-        act: nn.Module,
-        norm: nn.Module,
-        order: List[str] = ["pool", "layer", "act", "norm"],
+        activation: nn.Module,
+        normalization: nn.Module,
+        order: List[str] = ["pool", "layer", "activation", "normalization"],
         **kwargs: nn.Module,
     ):
         super().__init__(
             pool=pool,
             layer=layer,
-            act=act,
-            norm=norm,
+            activation=activation,
+            normalization=normalization,
             order=order,
             **kwargs,
         )
@@ -45,7 +45,7 @@ class PoolLayerActNorm(SequentialBlock):
         self,
         order: Optional[List[str]],
         layer: Optional[nn.Module],
-        act: Optional[nn.Module],
+        activation: Optional[nn.Module],
         **kwargs: nn.Module,
     ) -> None:
         ...
@@ -55,11 +55,11 @@ class PoolLayerActNorm(SequentialBlock):
         ...
 
     @overload
-    def configure(self, name: Literal["act"], *args, **kwargs) -> None:
+    def configure(self, name: Literal["activation"], *args, **kwargs) -> None:
         ...
 
     @overload
-    def configure(self, name: Literal["norm"], *args, **kwargs) -> None:
+    def configure(self, name: Literal["normalization"], *args, **kwargs) -> None:
         ...
 
     @overload

--- a/deeplay/blocks/PLAN.py
+++ b/deeplay/blocks/PLAN.py
@@ -1,0 +1,73 @@
+from typing import (
+    List,
+    overload,
+    Optional,
+    Literal,
+    Any,
+)
+
+import torch.nn as nn
+
+from .sequential import SequentialBlock
+
+
+class PoolLayerActivationNormalizationBlock(SequentialBlock):
+    layer: nn.Module
+    activation: nn.Module
+    normalization: nn.Module
+    order: List[str]
+
+    def __init__(
+        self,
+        pool: nn.Module,
+        layer: nn.Module,
+        activation: nn.Module,
+        normalization: nn.Module,
+        order: List[str] = ["pool", "layer", "activation", "normalization"],
+        **kwargs: nn.Module,
+    ):
+        super().__init__(
+            pool=pool,
+            layer=layer,
+            activation=activation,
+            normalization=normalization,
+            order=order,
+            **kwargs,
+        )
+
+    @overload
+    def configure(self, **kwargs: nn.Module) -> None:
+        ...
+
+    @overload
+    def configure(
+        self,
+        order: Optional[List[str]],
+        layer: Optional[nn.Module],
+        activation: Optional[nn.Module],
+        **kwargs: nn.Module,
+    ) -> None:
+        ...
+
+    @overload
+    def configure(self, name: Literal["layer"], *args, **kwargs) -> None:
+        ...
+
+    @overload
+    def configure(self, name: Literal["activation"], *args, **kwargs) -> None:
+        ...
+
+    @overload
+    def configure(self, name: Literal["normalization"], *args, **kwargs) -> None:
+        ...
+
+    @overload
+    def configure(self, name: Literal["pool"], *args, **kwargs) -> None:
+        ...
+
+    @overload
+    def configure(self, name: str, *args, **kwargs: Any) -> None:
+        ...
+
+    def configure(self, *args, **kwargs):  # type: ignore
+        super().configure(*args, **kwargs)

--- a/deeplay/blocks/PLAN.py
+++ b/deeplay/blocks/PLAN.py
@@ -12,6 +12,7 @@ from .sequential import SequentialBlock
 
 
 class PoolLayerActivationNormalizationBlock(SequentialBlock):
+    pool: nn.Module
     layer: nn.Module
     activation: nn.Module
     normalization: nn.Module

--- a/deeplay/blocks/PLAN.py
+++ b/deeplay/blocks/PLAN.py
@@ -11,27 +11,27 @@ import torch.nn as nn
 from .sequential import SequentialBlock
 
 
-class PoolLayerActivationNormalizationBlock(SequentialBlock):
+class PoolLayerActNorm(SequentialBlock):
     pool: nn.Module
     layer: nn.Module
-    activation: nn.Module
-    normalization: nn.Module
+    act: nn.Module
+    norm: nn.Module
     order: List[str]
 
     def __init__(
         self,
         pool: nn.Module,
         layer: nn.Module,
-        activation: nn.Module,
-        normalization: nn.Module,
-        order: List[str] = ["pool", "layer", "activation", "normalization"],
+        act: nn.Module,
+        norm: nn.Module,
+        order: List[str] = ["pool", "layer", "act", "norm"],
         **kwargs: nn.Module,
     ):
         super().__init__(
             pool=pool,
             layer=layer,
-            activation=activation,
-            normalization=normalization,
+            act=act,
+            norm=norm,
             order=order,
             **kwargs,
         )
@@ -45,7 +45,7 @@ class PoolLayerActivationNormalizationBlock(SequentialBlock):
         self,
         order: Optional[List[str]],
         layer: Optional[nn.Module],
-        activation: Optional[nn.Module],
+        act: Optional[nn.Module],
         **kwargs: nn.Module,
     ) -> None:
         ...
@@ -55,11 +55,11 @@ class PoolLayerActivationNormalizationBlock(SequentialBlock):
         ...
 
     @overload
-    def configure(self, name: Literal["activation"], *args, **kwargs) -> None:
+    def configure(self, name: Literal["act"], *args, **kwargs) -> None:
         ...
 
     @overload
-    def configure(self, name: Literal["normalization"], *args, **kwargs) -> None:
+    def configure(self, name: Literal["norm"], *args, **kwargs) -> None:
         ...
 
     @overload

--- a/deeplay/blocks/__init__.py
+++ b/deeplay/blocks/__init__.py
@@ -1,4 +1,4 @@
 from .block import Block
-from .LA import LayerAct
-from .LAN import LayerActNorm
-from .PLAN import PoolLayerActNorm
+from .LA import LayerActivation
+from .LAN import LayerActivationNormalization
+from .PLAN import PoolLayerActivationNormalization

--- a/deeplay/blocks/__init__.py
+++ b/deeplay/blocks/__init__.py
@@ -1,4 +1,4 @@
 from .block import Block
-from .LA import LayerActivationBlock
-from .LAN import LayerActivationNormalizationBlock
-from .PLAN import PoolLayerActivationNormalizationBlock
+from .LA import LayerAct
+from .LAN import LayerActNorm
+from .PLAN import PoolLayerActNorm

--- a/deeplay/blocks/__init__.py
+++ b/deeplay/blocks/__init__.py
@@ -1,3 +1,4 @@
 from .block import Block
 from .LA import LayerActivationBlock
 from .LAN import LayerActivationNormalizationBlock
+from .PLAN import PoolLayerActivationNormalizationBlock

--- a/deeplay/components/__init__.py
+++ b/deeplay/components/__init__.py
@@ -1,3 +1,2 @@
-
 from .mlp import MultiLayerPerceptron
-
+from .cnn import *

--- a/deeplay/components/cnn/__init__.py
+++ b/deeplay/components/cnn/__init__.py
@@ -1,0 +1,1 @@
+from .cnn import ConvolutionalNeuralNetwork

--- a/deeplay/components/cnn/cnn.py
+++ b/deeplay/components/cnn/cnn.py
@@ -6,20 +6,34 @@ import torch.nn as nn
 
 
 class ConvolutionalNeuralNetwork(DeeplayModule):
-    """Convolutional Neural Network (CNN) module.
+        """Convolutional Neural Network (CNN) module.
+
+    Parameters
+    ----------
+    in_channels: int or None
+        Number of input features. If None, the input shape is inferred from the first forward pass
+    hidden_channels: list[int]
+        Number of hidden units in each layer
+    out_channels: int
+        Number of output features
+    out_activation: template-like
+        Specification for the output act of the MLP. (Default: nn.Identity)
+    pool: template-like
+        Specification for the pooling of the block. Is not applied to the first block. (Default: nn.Identity)
+
 
     Configurables
     -------------
-
-    - in_channels (int): Number of input features. If None, the input shape is inferred from the first forward pass. (Default: None)
-    - hidden_channels (list[int]): Number of hidden units in each layer. (Default: [32, 32])
-    - out_channels (int): Number of output features. (Default: 1)
-    - blocks (template-like): Specification for the blocks of the MLP. (Default: "layer" >> "activation" >> "normalization" >> "dropout")
+    - in_channels (int): Number of input features. If None, the input shape is inferred from the first forward pass.
+    - hidden_channels (list[int]): Number of hidden units in each layer.
+    - out_channels (int): Number of output features.
+    - blocks (template-like): Specification for the blocks of the CNN. (Default: "layer" >> "act" >> "norm" >> "dropout")
+        - pool (template-like): Specification for the pooling of the block. (Default: nn.Identity)
         - layer (template-like): Specification for the layer of the block. (Default: nn.Linear)
-        - activation (template-like): Specification for the activation of the block. (Default: nn.ReLU)
-        - normalization (template-like): Specification for the normalization of the block. (Default: nn.Identity)
+        - act (template-like): Specification for the act of the block. (Default: nn.ReLU)
+        - norm (template-like): Specification for the norm of the block. (Default: nn.Identity)
         - dropout (template-like): Specification for the dropout of the block. (Default: nn.Identity)
-    - out_activation (template-like): Specification for the output activation of the MLP. (Default: nn.Identity)
+    - out_activation (template-like): Specification for the output act of the MLP. (Default: nn.Identity)
 
     Constraints
     -----------
@@ -36,8 +50,8 @@ class ConvolutionalNeuralNetwork(DeeplayModule):
     --------
     >>> # Using default values
     >>> cnn = ConvolutionalNeuralNetwork(3, [32, 64, 128], 1)
-    >>> # Customizing output activation
-    >>> cnn.output_block.activation(nn.Sigmoid)
+    >>> # Customizing output act
+    >>> cnn.output_block.act(nn.Sigmoid)
     >>> # Changing the kernel size of the first layer
     >>> cnn.input_block.layer.kernel_size(5)
 

--- a/deeplay/components/cnn/cnn.py
+++ b/deeplay/components/cnn/cnn.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Literal, Any, Sequence, Type, overload
 
-from ... import DeeplayModule, Layer, LayerList, LayerActivationNormalizationBlock
+from ... import DeeplayModule, Layer, LayerList, PoolLayerActivationNormalizationBlock
 
 import torch.nn as nn
 
@@ -55,7 +55,7 @@ class ConvolutionalNeuralNetwork(DeeplayModule):
     in_channels: Optional[int]
     hidden_channels: Sequence[Optional[int]]
     out_channels: int
-    blocks: LayerList[LayerActivationNormalizationBlock]
+    blocks: LayerList[PoolLayerActivationNormalizationBlock]
 
     @property
     def input_block(self):
@@ -109,7 +109,8 @@ class ConvolutionalNeuralNetwork(DeeplayModule):
             c_in = self.in_channels if i == 0 else self.hidden_channels[i - 1]
 
             self.blocks.append(
-                LayerActivationNormalizationBlock(
+                PoolLayerActivationNormalizationBlock(
+                    Layer(nn.Identity),
                     Layer(nn.Conv2d, c_in, c_out, 3, 1, 1)
                     if c_in
                     else Layer(nn.LazyConv2d, c_out, 3, 1, 1),
@@ -122,7 +123,8 @@ class ConvolutionalNeuralNetwork(DeeplayModule):
             )
 
         self.blocks.append(
-            LayerActivationNormalizationBlock(
+            PoolLayerActivationNormalizationBlock(
+                Layer(nn.Identity),
                 Layer(nn.Conv2d, c_out, self.out_channels, 3, 1, 1),
                 out_activation,
                 Layer(nn.Identity, num_channels=self.out_channels),

--- a/deeplay/components/cnn/cnn.py
+++ b/deeplay/components/cnn/cnn.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Literal, Any, Sequence, Type, overload
 
-from ... import DeeplayModule, Layer, LayerList, PoolLayerActivationNormalizationBlock
+from ... import DeeplayModule, Layer, LayerList, PoolLayerActNorm
 
 import torch.nn as nn
 
@@ -14,12 +14,12 @@ class ConvolutionalNeuralNetwork(DeeplayModule):
     - in_channels (int): Number of input features. If None, the input shape is inferred from the first forward pass. (Default: None)
     - hidden_channels (list[int]): Number of hidden units in each layer. (Default: [32, 32])
     - out_channels (int): Number of output features. (Default: 1)
-    - blocks (template-like): Specification for the blocks of the MLP. (Default: "layer" >> "activation" >> "normalization" >> "dropout")
+    - blocks (template-like): Specification for the blocks of the MLP. (Default: "layer" >> "act" >> "norm" >> "dropout")
         - layer (template-like): Specification for the layer of the block. (Default: nn.Linear)
-        - activation (template-like): Specification for the activation of the block. (Default: nn.ReLU)
-        - normalization (template-like): Specification for the normalization of the block. (Default: nn.Identity)
+        - act (template-like): Specification for the act of the block. (Default: nn.ReLU)
+        - norm (template-like): Specification for the norm of the block. (Default: nn.Identity)
         - dropout (template-like): Specification for the dropout of the block. (Default: nn.Identity)
-    - out_activation (template-like): Specification for the output activation of the MLP. (Default: nn.Identity)
+    - out_activation (template-like): Specification for the output act of the MLP. (Default: nn.Identity)
 
     Constraints
     -----------
@@ -36,8 +36,8 @@ class ConvolutionalNeuralNetwork(DeeplayModule):
     --------
     >>> # Using default values
     >>> cnn = ConvolutionalNeuralNetwork(3, [32, 64, 128], 1)
-    >>> # Customizing output activation
-    >>> cnn.output_block.activation(nn.Sigmoid)
+    >>> # Customizing output act
+    >>> cnn.output_block.act(nn.Sigmoid)
     >>> # Changing the kernel size of the first layer
     >>> cnn.input_block.layer.kernel_size(5)
 
@@ -55,7 +55,7 @@ class ConvolutionalNeuralNetwork(DeeplayModule):
     in_channels: Optional[int]
     hidden_channels: Sequence[Optional[int]]
     out_channels: int
-    blocks: LayerList[PoolLayerActivationNormalizationBlock]
+    blocks: LayerList[PoolLayerActNorm]
 
     @property
     def input_block(self):
@@ -109,7 +109,7 @@ class ConvolutionalNeuralNetwork(DeeplayModule):
             c_in = self.in_channels if i == 0 else self.hidden_channels[i - 1]
 
             self.blocks.append(
-                PoolLayerActivationNormalizationBlock(
+                PoolLayerActNorm(
                     Layer(nn.Identity),
                     Layer(nn.Conv2d, c_in, c_out, 3, 1, 1)
                     if c_in
@@ -123,7 +123,7 @@ class ConvolutionalNeuralNetwork(DeeplayModule):
             )
 
         self.blocks.append(
-            PoolLayerActivationNormalizationBlock(
+            PoolLayerActNorm(
                 Layer(nn.Identity),
                 Layer(nn.Conv2d, c_out, self.out_channels, 3, 1, 1),
                 out_activation,
@@ -153,8 +153,8 @@ class ConvolutionalNeuralNetwork(DeeplayModule):
         name: Literal["blocks"],
         order: Optional[Sequence[str]] = None,
         layer: Optional[Type[nn.Module]] = None,
-        activation: Optional[Type[nn.Module]] = None,
-        normalization: Optional[Type[nn.Module]] = None,
+        act: Optional[Type[nn.Module]] = None,
+        norm: Optional[Type[nn.Module]] = None,
         **kwargs: Any,
     ) -> None:
         ...
@@ -166,8 +166,8 @@ class ConvolutionalNeuralNetwork(DeeplayModule):
         index: int | slice | List[int | slice],
         order: Optional[Sequence[str]] = None,
         layer: Optional[Type[nn.Module]] = None,
-        activation: Optional[Type[nn.Module]] = None,
-        normalization: Optional[Type[nn.Module]] = None,
+        act: Optional[Type[nn.Module]] = None,
+        norm: Optional[Type[nn.Module]] = None,
         **kwargs: Any,
     ) -> None:
         ...

--- a/deeplay/components/cnn/cnn.py
+++ b/deeplay/components/cnn/cnn.py
@@ -1,0 +1,169 @@
+from typing import List, Optional, Literal, Any, Sequence, Type, overload
+
+from ... import DeeplayModule, Layer, LayerList, LayerActivationNormalizationBlock
+
+import torch.nn as nn
+
+
+class ConvolutionalNeuralNetwork(DeeplayModule):
+    """Convolutional Neural Network (CNN) module.
+
+    Configurables
+    -------------
+
+    - in_channels (int): Number of input features. If None, the input shape is inferred from the first forward pass. (Default: None)
+    - hidden_channels (list[int]): Number of hidden units in each layer. (Default: [32, 32])
+    - out_channels (int): Number of output features. (Default: 1)
+    - blocks (template-like): Specification for the blocks of the MLP. (Default: "layer" >> "activation" >> "normalization" >> "dropout")
+        - layer (template-like): Specification for the layer of the block. (Default: nn.Linear)
+        - activation (template-like): Specification for the activation of the block. (Default: nn.ReLU)
+        - normalization (template-like): Specification for the normalization of the block. (Default: nn.Identity)
+        - dropout (template-like): Specification for the dropout of the block. (Default: nn.Identity)
+    - out_activation (template-like): Specification for the output activation of the MLP. (Default: nn.Identity)
+
+    Constraints
+    -----------
+    - input shape: (batch_size, ch_in)
+    - output shape: (batch_size, ch_out)
+
+    Evaluation
+    ----------
+    >>> for block in mlp.blocks:
+    >>>    x = block(x)
+    >>> return x
+
+    Examples
+    --------
+    >>> # Using default values
+    >>> mlp = MultiLayerPerceptron(28 * 28, [128], 10)
+    >>> # Customizing output activation
+    >>> mlp = MultiLayerPerceptron(28 * 28, [128], 1, nn.Sigmoid)
+    >>> # Using from_config with custom normalization
+    >>> mlp = MultiLayerPerceptron.from_config(
+    >>>     Config()
+    >>>     .in_channels(28 * 28)
+    >>>     .hidden_channels([128])
+    >>>     .out_channels(1)
+    >>>     .out_activation(nn.Sigmoid)
+    >>>     .blocks[0].normalization(nn.BatchNorm1d, num_features=128)
+    >>> )
+
+    Return Values
+    -------------
+    The forward method returns the processed tensor.
+
+    Additional Notes
+    ----------------
+    The `Config` and `Layer` classes are used for configuring the blocks of the MLP. For more details refer to [Config Documentation](#) and [Layer Documentation](#).
+
+    """
+
+    in_channels: Optional[int]
+    hidden_channels: Sequence[Optional[int]]
+    out_channels: int
+    blocks: LayerList[LayerActivationNormalizationBlock]
+
+    @property
+    def input(self):
+        """Return the input layer of the network. Equivalent to `.blocks[0]`."""
+        return self.blocks[0]
+
+    @property
+    def hidden(self):
+        """Return the hidden layers of the network. Equivalent to `.blocks[:-1]`"""
+        return self.blocks[:-1]
+
+    @property
+    def output(self):
+        """Return the last layer of the network. Equivalent to `.blocks[-1]`."""
+        return self.blocks[-1]
+
+    def __init__(
+        self,
+        in_channels: Optional[int],
+        hidden_channels: Sequence[int],
+        out_channels: int,
+        out_activation: Type[nn.Module] | nn.Module | None = None,
+    ):
+        super().__init__()
+
+        self.in_channels = in_channels
+        self.hidden_channels = hidden_channels
+        self.out_channels = out_channels
+
+        if out_activation is None:
+            out_activation = Layer(nn.Identity)
+        elif isinstance(out_activation, type) and issubclass(out_activation, nn.Module):
+            out_activation = Layer(out_activation)
+
+        self.blocks = LayerList()
+        for i, c_out in enumerate(self.hidden_channels):
+            c_in = self.in_channels if i == 0 else self.hidden_channels[i - 1]
+
+            self.blocks.append(
+                LayerActivationNormalizationBlock(
+                    Layer(nn.Conv2d, c_in, c_out, 3)
+                    if c_in
+                    else Layer(
+                        nn.LazyConv2d,
+                        c_out,
+                        3,
+                    ),
+                    Layer(nn.ReLU),
+                    # We can give num_features as an argument to nn.Identity
+                    # because it is ignored. This means that users do not have
+                    # to specify the number of features for nn.Identity.
+                    Layer(nn.Identity, num_features=out_channels),
+                )
+            )
+
+        self.blocks.append(
+            LayerActivationNormalizationBlock(
+                Layer(nn.Conv2d, self.hidden_channels[-1], self.out_channels, 3),
+                out_activation,
+                Layer(nn.Identity, num_channels=self.out_channels),
+            )
+        )
+
+    def forward(self, x):
+        for block in self.blocks:
+            x = block(x)
+        return x
+
+    @overload
+    def configure(
+        self,
+        /,
+        in_channels: int | None = None,
+        hidden_channels: List[int] | None = None,
+        out_channels: int | None = None,
+        out_activation: Type[nn.Module] | nn.Module | None = None,
+    ) -> None:
+        ...
+
+    @overload
+    def configure(
+        self,
+        name: Literal["blocks"],
+        order: Optional[Sequence[str]] = None,
+        layer: Optional[Type[nn.Module]] = None,
+        activation: Optional[Type[nn.Module]] = None,
+        normalization: Optional[Type[nn.Module]] = None,
+        **kwargs: Any,
+    ) -> None:
+        ...
+
+    @overload
+    def configure(
+        self,
+        name: Literal["blocks"],
+        index: int | slice | List[int | slice],
+        order: Optional[Sequence[str]] = None,
+        layer: Optional[Type[nn.Module]] = None,
+        activation: Optional[Type[nn.Module]] = None,
+        normalization: Optional[Type[nn.Module]] = None,
+        **kwargs: Any,
+    ) -> None:
+        ...
+
+    configure = DeeplayModule.configure

--- a/deeplay/components/cnn/cnn.py
+++ b/deeplay/components/cnn/cnn.py
@@ -1,12 +1,12 @@
 from typing import List, Optional, Literal, Any, Sequence, Type, overload
 
-from ... import DeeplayModule, Layer, LayerList, PoolLayerActNorm
+from ... import DeeplayModule, Layer, LayerList, PoolLayerActivationNormalization
 
 import torch.nn as nn
 
 
 class ConvolutionalNeuralNetwork(DeeplayModule):
-        """Convolutional Neural Network (CNN) module.
+    """Convolutional Neural Network (CNN) module.
 
     Parameters
     ----------
@@ -17,7 +17,7 @@ class ConvolutionalNeuralNetwork(DeeplayModule):
     out_channels: int
         Number of output features
     out_activation: template-like
-        Specification for the output act of the MLP. (Default: nn.Identity)
+        Specification for the output activation of the MLP. (Default: nn.Identity)
     pool: template-like
         Specification for the pooling of the block. Is not applied to the first block. (Default: nn.Identity)
 
@@ -31,7 +31,7 @@ class ConvolutionalNeuralNetwork(DeeplayModule):
     out_channels: int
         Number of output features
     out_activation: template-like
-        Specification for the output act of the MLP. (Default: nn.Identity)
+        Specification for the output activation of the MLP. (Default: nn.Identity)
     pool: template-like
         Specification for the pooling of the block. Is not applied to the first block. (Default: nn.Identity)
 
@@ -41,13 +41,13 @@ class ConvolutionalNeuralNetwork(DeeplayModule):
     - in_channels (int): Number of input features. If None, the input shape is inferred from the first forward pass.
     - hidden_channels (list[int]): Number of hidden units in each layer.
     - out_channels (int): Number of output features.
-    - blocks (template-like): Specification for the blocks of the CNN. (Default: "layer" >> "act" >> "norm" >> "dropout")
+    - blocks (template-like): Specification for the blocks of the CNN. (Default: "layer" >> "activation" >> "normalization" >> "dropout")
         - pool (template-like): Specification for the pooling of the block. (Default: nn.Identity)
         - layer (template-like): Specification for the layer of the block. (Default: nn.Linear)
-        - act (template-like): Specification for the act of the block. (Default: nn.ReLU)
-        - norm (template-like): Specification for the norm of the block. (Default: nn.Identity)
+        - activation (template-like): Specification for the activation of the block. (Default: nn.ReLU)
+        - normalization (template-like): Specification for the normalization of the block. (Default: nn.Identity)
         - dropout (template-like): Specification for the dropout of the block. (Default: nn.Identity)
-    - out_activation (template-like): Specification for the output act of the MLP. (Default: nn.Identity)
+    - out_activation (template-like): Specification for the output activation of the MLP. (Default: nn.Identity)
 
     Constraints
     -----------
@@ -64,8 +64,8 @@ class ConvolutionalNeuralNetwork(DeeplayModule):
     --------
     >>> # Using default values
     >>> cnn = ConvolutionalNeuralNetwork(3, [32, 64, 128], 1)
-    >>> # Customizing output act
-    >>> cnn.output_block.act(nn.Sigmoid)
+    >>> # Customizing output activation
+    >>> cnn.output_block.activation(nn.Sigmoid)
     >>> # Changing the kernel size of the first layer
     >>> cnn.input_block.layer.kernel_size(5)
 
@@ -83,7 +83,7 @@ class ConvolutionalNeuralNetwork(DeeplayModule):
     in_channels: Optional[int]
     hidden_channels: Sequence[Optional[int]]
     out_channels: int
-    blocks: LayerList[PoolLayerActNorm]
+    blocks: LayerList[PoolLayerActivationNormalization]
 
     @property
     def input_block(self):
@@ -143,7 +143,7 @@ class ConvolutionalNeuralNetwork(DeeplayModule):
             c_in = self.in_channels if i == 0 else self.hidden_channels[i - 1]
 
             self.blocks.append(
-                PoolLayerActNorm(
+                PoolLayerActivationNormalization(
                     pool if i > 0 else Layer(nn.Identity),
                     Layer(nn.Conv2d, c_in, c_out, 3, 1, 1)
                     if c_in
@@ -157,7 +157,7 @@ class ConvolutionalNeuralNetwork(DeeplayModule):
             )
 
         self.blocks.append(
-            PoolLayerActNorm(
+            PoolLayerActivationNormalization(
                 pool if len(self.hidden_channels) > 0 else Layer(nn.Identity),
                 Layer(nn.Conv2d, c_out, self.out_channels, 3, 1, 1),
                 out_activation,
@@ -187,8 +187,8 @@ class ConvolutionalNeuralNetwork(DeeplayModule):
         name: Literal["blocks"],
         order: Optional[Sequence[str]] = None,
         layer: Optional[Type[nn.Module]] = None,
-        act: Optional[Type[nn.Module]] = None,
-        norm: Optional[Type[nn.Module]] = None,
+        activation: Optional[Type[nn.Module]] = None,
+        normalization: Optional[Type[nn.Module]] = None,
         **kwargs: Any,
     ) -> None:
         ...
@@ -200,8 +200,8 @@ class ConvolutionalNeuralNetwork(DeeplayModule):
         index: int | slice | List[int | slice],
         order: Optional[Sequence[str]] = None,
         layer: Optional[Type[nn.Module]] = None,
-        act: Optional[Type[nn.Module]] = None,
-        norm: Optional[Type[nn.Module]] = None,
+        activation: Optional[Type[nn.Module]] = None,
+        normalization: Optional[Type[nn.Module]] = None,
         **kwargs: Any,
     ) -> None:
         ...

--- a/deeplay/components/cnn/cnn.py
+++ b/deeplay/components/cnn/cnn.py
@@ -35,18 +35,12 @@ class ConvolutionalNeuralNetwork(DeeplayModule):
     Examples
     --------
     >>> # Using default values
-    >>> mlp = MultiLayerPerceptron(28 * 28, [128], 10)
+    >>> cnn = ConvolutionalNeuralNetwork(3, [32, 64, 128], 1)
     >>> # Customizing output activation
-    >>> mlp = MultiLayerPerceptron(28 * 28, [128], 1, nn.Sigmoid)
-    >>> # Using from_config with custom normalization
-    >>> mlp = MultiLayerPerceptron.from_config(
-    >>>     Config()
-    >>>     .in_channels(28 * 28)
-    >>>     .hidden_channels([128])
-    >>>     .out_channels(1)
-    >>>     .out_activation(nn.Sigmoid)
-    >>>     .blocks[0].normalization(nn.BatchNorm1d, num_features=128)
-    >>> )
+    >>> cnn.output_block.activation(nn.Sigmoid)
+    >>> # Changing the kernel size of the first layer
+    >>> cnn.input_block.layer.kernel_size(5)
+
 
     Return Values
     -------------
@@ -64,17 +58,17 @@ class ConvolutionalNeuralNetwork(DeeplayModule):
     blocks: LayerList[LayerActivationNormalizationBlock]
 
     @property
-    def input(self):
+    def input_block(self):
         """Return the input layer of the network. Equivalent to `.blocks[0]`."""
         return self.blocks[0]
 
     @property
-    def hidden(self):
+    def hidden_blocks(self):
         """Return the hidden layers of the network. Equivalent to `.blocks[:-1]`"""
         return self.blocks[:-1]
 
     @property
-    def output(self):
+    def output_block(self):
         """Return the last layer of the network. Equivalent to `.blocks[-1]`."""
         return self.blocks[-1]
 

--- a/deeplay/components/mlp.py
+++ b/deeplay/components/mlp.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Literal, Any, Sequence, Type, overload
 
-from .. import DeeplayModule, Layer, LayerList, LayerActivationNormalizationBlock
+from .. import DeeplayModule, Layer, LayerList, LayerActNorm
 
 import torch.nn as nn
 
@@ -16,12 +16,12 @@ class MultiLayerPerceptron(DeeplayModule):
     - in_features (int): Number of input features. If None, the input shape is inferred from the first forward pass. (Default: None)
     - hidden_dims (list[int]): Number of hidden units in each layer. (Default: [32, 32])
     - out_features (int): Number of output features. (Default: 1)
-    - blocks (template-like): Specification for the blocks of the MLP. (Default: "layer" >> "activation" >> "normalization" >> "dropout")
+    - blocks (template-like): Specification for the blocks of the MLP. (Default: "layer" >> "act" >> "norm" >> "dropout")
         - layer (template-like): Specification for the layer of the block. (Default: nn.Linear)
-        - activation (template-like): Specification for the activation of the block. (Default: nn.ReLU)
-        - normalization (template-like): Specification for the normalization of the block. (Default: nn.Identity)
+        - act (template-like): Specification for the act of the block. (Default: nn.ReLU)
+        - norm (template-like): Specification for the norm of the block. (Default: nn.Identity)
         - dropout (template-like): Specification for the dropout of the block. (Default: nn.Identity)
-    - out_activation (template-like): Specification for the output activation of the MLP. (Default: nn.Identity)
+    - out_activation (template-like): Specification for the output act of the MLP. (Default: nn.Identity)
 
     Constraints
     -----------
@@ -38,16 +38,16 @@ class MultiLayerPerceptron(DeeplayModule):
     --------
     >>> # Using default values
     >>> mlp = MultiLayerPerceptron(28 * 28, [128], 10)
-    >>> # Customizing output activation
+    >>> # Customizing output act
     >>> mlp = MultiLayerPerceptron(28 * 28, [128], 1, nn.Sigmoid)
-    >>> # Using from_config with custom normalization
+    >>> # Using from_config with custom norm
     >>> mlp = MultiLayerPerceptron.from_config(
     >>>     Config()
     >>>     .in_features(28 * 28)
     >>>     .hidden_dims([128])
     >>>     .out_features(1)
     >>>     .out_activation(nn.Sigmoid)
-    >>>     .blocks[0].normalization(nn.BatchNorm1d, num_features=128)
+    >>>     .blocks[0].norm(nn.BatchNorm1d, num_features=128)
     >>> )
 
     Return Values
@@ -63,8 +63,8 @@ class MultiLayerPerceptron(DeeplayModule):
     in_features: Optional[int]
     hidden_dims: Sequence[Optional[int]]
     out_features: int
-    blocks: LayerList[LayerActivationNormalizationBlock]
-    out_layer: LayerActivationNormalizationBlock
+    blocks: LayerList[LayerActNorm]
+    out_layer: LayerActNorm
 
     def __init__(
         self,
@@ -89,7 +89,7 @@ class MultiLayerPerceptron(DeeplayModule):
             f_in = self.in_features if i == 0 else self.hidden_dims[i - 1]
 
             self.blocks.append(
-                LayerActivationNormalizationBlock(
+                LayerActNorm(
                     Layer(nn.Linear, f_in, f_out)
                     if f_in
                     else Layer(nn.LazyLinear, f_out),
@@ -101,7 +101,7 @@ class MultiLayerPerceptron(DeeplayModule):
                 )
             )
 
-        self.out_layer = LayerActivationNormalizationBlock(
+        self.out_layer = LayerActNorm(
             Layer(nn.Linear, self.hidden_dims[-1], self.out_features),
             out_activation,
             Layer(nn.Identity, num_features=self.out_features),
@@ -131,8 +131,8 @@ class MultiLayerPerceptron(DeeplayModule):
         name: Literal["out_layer", "blocks"],
         order: Optional[Sequence[str]] = None,
         layer: Optional[Type[nn.Module]] = None,
-        activation: Optional[Type[nn.Module]] = None,
-        normalization: Optional[Type[nn.Module]] = None,
+        act: Optional[Type[nn.Module]] = None,
+        norm: Optional[Type[nn.Module]] = None,
         **kwargs: Any,
     ) -> None:
         ...
@@ -144,8 +144,8 @@ class MultiLayerPerceptron(DeeplayModule):
         index: int | slice | List[int | slice] | None = None,
         order: Optional[Sequence[str]] = None,
         layer: Optional[Type[nn.Module]] = None,
-        activation: Optional[Type[nn.Module]] = None,
-        normalization: Optional[Type[nn.Module]] = None,
+        act: Optional[Type[nn.Module]] = None,
+        norm: Optional[Type[nn.Module]] = None,
         **kwargs: Any,
     ) -> None:
         ...

--- a/deeplay/module.py
+++ b/deeplay/module.py
@@ -76,7 +76,7 @@ class DeeplayModule(nn.Module, metaclass=ExtendedConstructorMeta):
     _is_constructing: bool = False
     _is_building: bool = False
 
-    __extra_configurables__: Liststr] = []
+    __extra_configurables__: List[str] = []
 
     _args: tuple
     _kwargs: dict

--- a/deeplay/tests/test_cnn.py
+++ b/deeplay/tests/test_cnn.py
@@ -43,26 +43,26 @@ class TestComponentCNN(unittest.TestCase):
         cnn.build()
         self.assertEqual(len(cnn.blocks), 3)
 
-    def test_change_activation(self):
+    def test_change_act(self):
         cnn = ConvolutionalNeuralNetwork(2, [4], 3)
         cnn.configure(out_activation=nn.Sigmoid)
         cnn.build()
         self.assertEqual(len(cnn.blocks), 2)
-        self.assertIsInstance(cnn.output_block.activation, nn.Sigmoid)
+        self.assertIsInstance(cnn.output_block.act, nn.Sigmoid)
 
-    def test_change_out_activation_Layer(self):
+    def test_change_out_act_Layer(self):
         cnn = ConvolutionalNeuralNetwork(2, [4], 3)
         cnn.configure(out_activation=Layer(nn.Sigmoid))
         cnn.build()
         self.assertEqual(len(cnn.blocks), 2)
-        self.assertIsInstance(cnn.output_block.activation, nn.Sigmoid)
+        self.assertIsInstance(cnn.output_block.act, nn.Sigmoid)
 
-    def test_change_out_activation_instance(self):
+    def test_change_out_act_instance(self):
         cnn = ConvolutionalNeuralNetwork(2, [4], 3)
         cnn.configure(out_activation=nn.Sigmoid())
         cnn.build()
         self.assertEqual(len(cnn.blocks), 2)
-        self.assertIsInstance(cnn.output_block.activation, nn.Sigmoid)
+        self.assertIsInstance(cnn.output_block.act, nn.Sigmoid)
 
     def test_default_values_initialization(self):
         cnn = ConvolutionalNeuralNetwork(

--- a/deeplay/tests/test_cnn.py
+++ b/deeplay/tests/test_cnn.py
@@ -48,21 +48,21 @@ class TestComponentCNN(unittest.TestCase):
         cnn.configure(out_activation=nn.Sigmoid)
         cnn.build()
         self.assertEqual(len(cnn.blocks), 2)
-        self.assertIsInstance(cnn.output_block.act, nn.Sigmoid)
+        self.assertIsInstance(cnn.output_block.activation, nn.Sigmoid)
 
     def test_change_out_act_Layer(self):
         cnn = ConvolutionalNeuralNetwork(2, [4], 3)
         cnn.configure(out_activation=Layer(nn.Sigmoid))
         cnn.build()
         self.assertEqual(len(cnn.blocks), 2)
-        self.assertIsInstance(cnn.output_block.act, nn.Sigmoid)
+        self.assertIsInstance(cnn.output_block.activation, nn.Sigmoid)
 
     def test_change_out_act_instance(self):
         cnn = ConvolutionalNeuralNetwork(2, [4], 3)
         cnn.configure(out_activation=nn.Sigmoid())
         cnn.build()
         self.assertEqual(len(cnn.blocks), 2)
-        self.assertIsInstance(cnn.output_block.act, nn.Sigmoid)
+        self.assertIsInstance(cnn.output_block.activation, nn.Sigmoid)
 
     def test_default_values_initialization(self):
         cnn = ConvolutionalNeuralNetwork(

--- a/deeplay/tests/test_cnn.py
+++ b/deeplay/tests/test_cnn.py
@@ -1,0 +1,90 @@
+import unittest
+import torch
+import torch.nn as nn
+from deeplay import ConvolutionalNeuralNetwork, Layer, LayerList
+
+
+class TestComponentCNN(unittest.TestCase):
+    ...
+
+    def test_cnn_defaults(self):
+        cnn = ConvolutionalNeuralNetwork(3, [4], 1)
+        cnn.build()
+        self.assertEqual(len(cnn.blocks), 2)
+
+        self.assertEqual(cnn.blocks[0].layer.in_channels, 3)
+        self.assertEqual(cnn.blocks[0].layer.out_channels, 4)
+
+        self.assertEqual(cnn.output_block.layer.in_channels, 4)
+        self.assertEqual(cnn.output_block.layer.out_channels, 1)
+
+        # test on a batch of 2
+        x = torch.randn(2, 3, 5, 5)
+        y = cnn(x)
+        self.assertEqual(y.shape, (2, 1, 5, 5))
+
+    def test_cnn_lazy_input(self):
+        cnn = ConvolutionalNeuralNetwork(None, [4], 1).build()
+        self.assertEqual(len(cnn.blocks), 2)
+
+        self.assertEqual(cnn.blocks[0].layer.in_channels, 0)
+        self.assertEqual(cnn.blocks[0].layer.out_channels, 4)
+        self.assertEqual(cnn.output_block.layer.in_channels, 4)
+        self.assertEqual(cnn.output_block.layer.out_channels, 1)
+
+        # test on a batch of 2
+        x = torch.randn(2, 3, 5, 5)
+        y = cnn(x)
+        self.assertEqual(y.shape, (2, 1, 5, 5))
+
+    def test_cnn_change_depth(self):
+        cnn = ConvolutionalNeuralNetwork(2, [4], 3)
+        cnn.configure(hidden_channels=[4, 4])
+        cnn.build()
+        self.assertEqual(len(cnn.blocks), 3)
+
+    def test_change_activation(self):
+        cnn = ConvolutionalNeuralNetwork(2, [4], 3)
+        cnn.configure(out_activation=nn.Sigmoid)
+        cnn.build()
+        self.assertEqual(len(cnn.blocks), 2)
+        self.assertIsInstance(cnn.output_block.activation, nn.Sigmoid)
+
+    def test_change_out_activation_Layer(self):
+        cnn = ConvolutionalNeuralNetwork(2, [4], 3)
+        cnn.configure(out_activation=Layer(nn.Sigmoid))
+        cnn.build()
+        self.assertEqual(len(cnn.blocks), 2)
+        self.assertIsInstance(cnn.output_block.activation, nn.Sigmoid)
+
+    def test_change_out_activation_instance(self):
+        cnn = ConvolutionalNeuralNetwork(2, [4], 3)
+        cnn.configure(out_activation=nn.Sigmoid())
+        cnn.build()
+        self.assertEqual(len(cnn.blocks), 2)
+        self.assertIsInstance(cnn.output_block.activation, nn.Sigmoid)
+
+    def test_default_values_initialization(self):
+        cnn = ConvolutionalNeuralNetwork(
+            in_channels=None, hidden_channels=[32, 32], out_channels=1
+        )
+        self.assertIsNone(cnn.in_channels)
+        self.assertEqual(cnn.hidden_channels, [32, 32])
+        self.assertEqual(cnn.out_channels, 1)
+        self.assertIsInstance(cnn.blocks, LayerList)
+
+    def test_empty_hidden_channels(self):
+        cnn = ConvolutionalNeuralNetwork(
+            in_channels=3, hidden_channels=[], out_channels=1
+        ).build()
+        self.assertEqual(cnn.blocks[0].layer.in_channels, 3)
+        self.assertEqual(cnn.blocks[0].layer.out_channels, 1)
+
+        self.assertIs(cnn.blocks[0], cnn.output_block)
+        self.assertIs(cnn.blocks[0], cnn.input_block)
+
+    def test_zero_out_channels(self):
+        with self.assertRaises(ValueError):
+            ConvolutionalNeuralNetwork(
+                in_channels=3, hidden_channels=[32, 64], out_channels=0
+            )

--- a/deeplay/tests/test_mlp.py
+++ b/deeplay/tests/test_mlp.py
@@ -48,18 +48,18 @@ class TestComponentMLP(unittest.TestCase):
         mlp.configure(out_activation=nn.Sigmoid)
         mlp.build()
         self.assertEqual(len(mlp.blocks), 1)
-        self.assertIsInstance(mlp.out_layer.act, nn.Sigmoid)
+        self.assertIsInstance(mlp.out_layer.activation, nn.Sigmoid)
 
     def test_change_out_activation_Layer(self):
         mlp = MultiLayerPerceptron(2, [4], 3)
         mlp.configure(out_activation=Layer(nn.Sigmoid))
         mlp.build()
         self.assertEqual(len(mlp.blocks), 1)
-        self.assertIsInstance(mlp.out_layer.act, nn.Sigmoid)
+        self.assertIsInstance(mlp.out_layer.activation, nn.Sigmoid)
 
     def test_change_out_activation_instance(self):
         mlp = MultiLayerPerceptron(2, [4], 3)
         mlp.configure(out_activation=nn.Sigmoid())
         mlp.build()
         self.assertEqual(len(mlp.blocks), 1)
-        self.assertIsInstance(mlp.out_layer.act, nn.Sigmoid)
+        self.assertIsInstance(mlp.out_layer.activation, nn.Sigmoid)

--- a/deeplay/tests/test_mlp.py
+++ b/deeplay/tests/test_mlp.py
@@ -48,18 +48,18 @@ class TestComponentMLP(unittest.TestCase):
         mlp.configure(out_activation=nn.Sigmoid)
         mlp.build()
         self.assertEqual(len(mlp.blocks), 1)
-        self.assertIsInstance(mlp.out_layer.activation, nn.Sigmoid)
+        self.assertIsInstance(mlp.out_layer.act, nn.Sigmoid)
 
     def test_change_out_activation_Layer(self):
         mlp = MultiLayerPerceptron(2, [4], 3)
         mlp.configure(out_activation=Layer(nn.Sigmoid))
         mlp.build()
         self.assertEqual(len(mlp.blocks), 1)
-        self.assertIsInstance(mlp.out_layer.activation, nn.Sigmoid)
+        self.assertIsInstance(mlp.out_layer.act, nn.Sigmoid)
 
     def test_change_out_activation_instance(self):
         mlp = MultiLayerPerceptron(2, [4], 3)
         mlp.configure(out_activation=nn.Sigmoid())
         mlp.build()
         self.assertEqual(len(mlp.blocks), 1)
-        self.assertIsInstance(mlp.out_layer.activation, nn.Sigmoid)
+        self.assertIsInstance(mlp.out_layer.act, nn.Sigmoid)


### PR DESCRIPTION
Adds a basic ConvolutionalNeuralNetwork, as well as an accompanying PoolLayerActivationNormalizationBlock.

## Open design questions

### We call it "pool"

No strong preference. We can also call it something else, like `"pooling"` or whatever comes to mind.

### Pooling is applied to the start of the block instead of at the end of the block. 

Main arguments for this choice is 
1. Makes it interchangeable with adding a stride to the conv layer. If at the end, then changing `pool=MaxPool`, to `layer.stride=2` will change if the pooling is done before or after activation and normalization. 
2. Plays more nicely with skip connections in for example unet. Since you generally want to make a skip from immediately before pooling, that means that you want to skip from the output of the previous block. If you apply pool last, you want to take an intermediate tensor in the block.
3. If you want to feed the CNN into another network, I think it's nicer to have the output of the CNN be the output of a learned layer, not a max pooling layer.

Drawback, I guess, is that you need to specify to not pool on the first block. Maybe some ambiguity here?

Of course, one can transform it into pool last by doing 
```python 
block.configure(order=["layer", "activation", "normalization", "pool"]
```

### We do not apply any pooling per default

While most CNNs apply pooling, I don't think it's warranted to have any pooling be the default choice so better to not apply any. 

We can add an input argument as a shorthand that defines the pooling to use. If so, should that shorthand apply to all blocks or all blocks except first? If all but first, and we then decide to do the same for activation and normalization, it may seem odd if they behave differently.

### We do apply a padding of 1 per default.

Just makes life easier. We can remove it if we want to adhere to the torch default of no padding.

### Tangentially related, too long names

The naming scheme for blocks is getting out of hand. `PoolLayerActivationNormalizationBlock` is very long.

We could just use SequentialBlock. The advantage of a specific block type is that we get static typing that tells the user that `block.pool` exists and is of type `Layer`. With SequentialBlock we don't have this.

We could abbreviate. `PLANBlock` is too non-descript I think. `PoolLayerActNormBlock` may work but I don't like that "act" and "norm" is not what we call it internally, i.e. activation and normalization.

Ideas?

## Additional notes

Want to note that for the design that is not covered above I intend to follow what is decided in #13 
