### PR TITLE
Allow LayerList to accept nn.Module objects

### DIFF
--- a/deeplay/list.py
+++ b/deeplay/list.py
@@ -1,8 +1,3 @@
-from torch import Tensor, nn
-from torch.nn.modules.container import ModuleList
-from torch.nn.modules.module import Module
-from .module import DeeplayModule
-
 from typing import (
     Any,
     overload,
@@ -12,7 +7,11 @@ from typing import (
     TypeVar,
 )
 
-T = TypeVar("T", bound=DeeplayModule)
+from torch import nn
+from .module import DeeplayModule
+
+
+T = TypeVar("T", bound=nn.Module)
 
 
 class LayerList(DeeplayModule, nn.ModuleList, Generic[T]):
@@ -33,8 +32,9 @@ class LayerList(DeeplayModule, nn.ModuleList, Generic[T]):
 
         for idx, layer in enumerate(layers):
             super().append(layer)
-            self._give_user_configuration(layer, self._get_abs_string_index(idx))
-            layer.__construct__()
+            if isinstance(layer, DeeplayModule):
+                self._give_user_configuration(layer, self._get_abs_string_index(idx))
+                layer.__construct__()
 
     def append(self, module: DeeplayModule) -> "LayerList[T]":
         if not self._has_built:

--- a/deeplay/tests/test_layerlist.py
+++ b/deeplay/tests/test_layerlist.py
@@ -157,3 +157,10 @@ class TestLayerList(unittest.TestCase):
                 self.assertEqual(list_33.layers[i][j][k].in_features, 4)
             else:
                 self.assertEqual(list_33.layers[i][j][k].in_features, 1)
+
+    def test_with_instantiated(self):
+        llist = LayerList(nn.Linear(1, 1), nn.Linear(1, 1))
+        llist.build()
+        self.assertEqual(len(llist), 2)
+        self.assertIsInstance(llist[0], nn.Linear)
+        self.assertIsInstance(llist[1], nn.Linear)


### PR DESCRIPTION
Generalizes LayerList to allow non-deeplay modules. So, previously,

```py
layer_list = LayerList(
    nn.Linear(64, 1),
    nn.Sigmoid(),
)
```

would not work. Instead it needed to be

```py
layer_list = LayerList(
    Layer(nn.Linear, 64, 1),
    Layer(nn.Sigmoid)
)
```

Passing instantiated nn.Linear instead of Layer-wrapped objects means that they are no longer configurable, but sometimes it is more convenient to pass nn.Modules directly. 