### PR TITLE
implement correct cnn shorthands

### DIFF
--- a/deeplay/components/cnn/cnn.py
+++ b/deeplay/components/cnn/cnn.py
@@ -86,19 +86,34 @@ class ConvolutionalNeuralNetwork(DeeplayModule):
     blocks: LayerList[PoolLayerActivationNormalization]
 
     @property
-    def input_block(self):
+    def input(self):
         """Return the input layer of the network. Equivalent to `.blocks[0]`."""
         return self.blocks[0]
 
     @property
-    def hidden_blocks(self):
+    def hidden(self):
         """Return the hidden layers of the network. Equivalent to `.blocks[:-1]`"""
         return self.blocks[:-1]
 
     @property
-    def output_block(self):
+    def output(self):
         """Return the last layer of the network. Equivalent to `.blocks[-1]`."""
         return self.blocks[-1]
+
+    @property
+    def layer(self) -> LayerList[Layer]:
+        """Return the layers of the network. Equivalent to `.blocks.layer`."""
+        return self.blocks.layer
+
+    @property
+    def activation(self) -> LayerList[Layer]:
+        """Return the activations of the network. Equivalent to `.blocks.activation`."""
+        return self.blocks.activation
+
+    @property
+    def normalization(self) -> LayerList[Layer]:
+        """Return the normalizations of the network. Equivalent to `.blocks.normalization`."""
+        return self.blocks.normalization
 
     def __init__(
         self,

--- a/deeplay/tests/test_cnn.py
+++ b/deeplay/tests/test_cnn.py
@@ -35,7 +35,7 @@ class TestComponentCNN(unittest.TestCase):
         # test on a batch of 2
         x = torch.randn(2, 3, 5, 5)
         y = cnn(x)
-        self.assertEqual(y.shape, (2, 1, 5, 5))
+        self.assertEqual(y.shape, (2, 1, 5, 5)) 
 
     def test_cnn_change_depth(self):
         cnn = ConvolutionalNeuralNetwork(2, [4], 3)

--- a/deeplay/tests/test_cnn.py
+++ b/deeplay/tests/test_cnn.py
@@ -15,8 +15,8 @@ class TestComponentCNN(unittest.TestCase):
         self.assertEqual(cnn.blocks[0].layer.in_channels, 3)
         self.assertEqual(cnn.blocks[0].layer.out_channels, 4)
 
-        self.assertEqual(cnn.output_block.layer.in_channels, 4)
-        self.assertEqual(cnn.output_block.layer.out_channels, 1)
+        self.assertEqual(cnn.output.layer.in_channels, 4)
+        self.assertEqual(cnn.output.layer.out_channels, 1)
 
         # test on a batch of 2
         x = torch.randn(2, 3, 5, 5)
@@ -27,10 +27,10 @@ class TestComponentCNN(unittest.TestCase):
         cnn = ConvolutionalNeuralNetwork(None, [4], 1).build()
         self.assertEqual(len(cnn.blocks), 2)
 
-        self.assertEqual(cnn.blocks[0].layer.in_channels, 0)
+        self.assertEqual(cnn.input.layer.in_channels, 0)
         self.assertEqual(cnn.blocks[0].layer.out_channels, 4)
-        self.assertEqual(cnn.output_block.layer.in_channels, 4)
-        self.assertEqual(cnn.output_block.layer.out_channels, 1)
+        self.assertEqual(cnn.output.layer.in_channels, 4)
+        self.assertEqual(cnn.output.layer.out_channels, 1)
 
         # test on a batch of 2
         x = torch.randn(2, 3, 5, 5)
@@ -48,21 +48,21 @@ class TestComponentCNN(unittest.TestCase):
         cnn.configure(out_activation=nn.Sigmoid)
         cnn.build()
         self.assertEqual(len(cnn.blocks), 2)
-        self.assertIsInstance(cnn.output_block.activation, nn.Sigmoid)
+        self.assertIsInstance(cnn.output.activation, nn.Sigmoid)
 
     def test_change_out_act_Layer(self):
         cnn = ConvolutionalNeuralNetwork(2, [4], 3)
         cnn.configure(out_activation=Layer(nn.Sigmoid))
         cnn.build()
         self.assertEqual(len(cnn.blocks), 2)
-        self.assertIsInstance(cnn.output_block.activation, nn.Sigmoid)
+        self.assertIsInstance(cnn.output.activation, nn.Sigmoid)
 
     def test_change_out_act_instance(self):
         cnn = ConvolutionalNeuralNetwork(2, [4], 3)
         cnn.configure(out_activation=nn.Sigmoid())
         cnn.build()
         self.assertEqual(len(cnn.blocks), 2)
-        self.assertIsInstance(cnn.output_block.activation, nn.Sigmoid)
+        self.assertIsInstance(cnn.output.activation, nn.Sigmoid)
 
     def test_default_values_initialization(self):
         cnn = ConvolutionalNeuralNetwork(
@@ -80,8 +80,8 @@ class TestComponentCNN(unittest.TestCase):
         self.assertEqual(cnn.blocks[0].layer.in_channels, 3)
         self.assertEqual(cnn.blocks[0].layer.out_channels, 1)
 
-        self.assertIs(cnn.blocks[0], cnn.output_block)
-        self.assertIs(cnn.blocks[0], cnn.input_block)
+        self.assertIs(cnn.blocks[0], cnn.input)
+        self.assertIs(cnn.blocks[0], cnn.output)
 
     def test_zero_out_channels(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Some of the shorthands were missing in the final merge to develop. This makes it consistent with MLP