### PR TITLE
Bm/allow-non-deeplay-list-get

### DIFF
--- a/deeplay/list.py
+++ b/deeplay/list.py
@@ -93,10 +93,7 @@ class LayerList(DeeplayModule, nn.ModuleList, Generic[T]):
                 raise
 
             submodules = [
-                getattr(layer, name)
-                for layer in self
-                if hasattr(layer, name)
-                and isinstance(getattr(layer, name), DeeplayModule)
+                getattr(layer, name) for layer in self if hasattr(layer, name)
             ]
             if len(submodules) > 0:
                 return LayerList(*submodules)

--- a/deeplay/list.py
+++ b/deeplay/list.py
@@ -93,7 +93,9 @@ class LayerList(DeeplayModule, nn.ModuleList, Generic[T]):
                 raise
 
             submodules = [
-                getattr(layer, name) for layer in self if hasattr(layer, name)
+                getattr(layer, name)
+                for layer in self
+                if hasattr(layer, name) and isinstance(getattr(layer, name), nn.Module)
             ]
             if len(submodules) > 0:
                 return LayerList(*submodules)

--- a/deeplay/tests/test_layerlist.py
+++ b/deeplay/tests/test_layerlist.py
@@ -164,3 +164,21 @@ class TestLayerList(unittest.TestCase):
         self.assertEqual(len(llist), 2)
         self.assertIsInstance(llist[0], nn.Linear)
         self.assertIsInstance(llist[1], nn.Linear)
+
+    def test_with_instantiated(self):
+        class Item(DeeplayModule):
+            def __init__(self):
+                self.net = Layer(nn.Linear, 1, 1)
+
+        llist = LayerList(Item(), Item())
+
+        nets = llist.net
+        self.assertEqual(len(nets), 2)
+        self.assertIsInstance(nets[0], Layer)
+        self.assertIsInstance(nets[1], Layer)
+
+        llist.build()
+        nets = llist.net
+        self.assertEqual(len(nets), 2)
+        self.assertIsInstance(nets[0], nn.Linear)
+        self.assertIsInstance(nets[1], nn.Linear)

--- a/deeplay/tests/test_layerlist.py
+++ b/deeplay/tests/test_layerlist.py
@@ -181,4 +181,4 @@ class TestLayerList(unittest.TestCase):
         nets = llist.net
         self.assertEqual(len(nets), 2)
         self.assertIsInstance(nets[0], nn.Linear)
-        self.assertIsInstance(nets[1], nn.Linear)
+        self.assertIsInstance(nets[1], nn.Linear) 


### PR DESCRIPTION
Changes LayerList attribute forwarding to allow any nn.Module instead of just DeeplayModule

The previous behanvior was a big confusing because the modules became inaccessable through attribute forwarding after build. E.G.

```py

layerlist = LayerList(
    LayerActivation(
        Layer(Linear, 1, 10),
        Layer(ReLU)
    ),
    LayerActivation(
        Layer(Linear, 10, 1),
        Layer(Sigmoid)
    ),
)

layerlist.activation # works, gets a list [Layer(ReLU), Layer(Sigmoid)]

layerlist.build()
layerlist.activation # crashes with attribute error, because they are no longer DeeplayModules
```

### What about any object?

It would be cool to allow any object, and I think it's a reasonable thing to implement in the future. 

Example use case would to get all the weights from a MLP:
```
mlp = MultiLayerPerceptron(64,  [32, 32], 1)
weights = mlp.layer.weight # list of weights in order
```
instead of
```
weights = [layer.weight for layer in mlp.layer]
```
However, the function returns a new `LayerList` of items, and `LayerList` extends `nn.ModuleList`, which can only hold `nn.Module`s. 

My prefered solution would maybe be to return some other object than a LayerList, like `Selection` which also has similar functionality as `LayerList` but doesn't subclass nn.ModuleList. However, in the interest of time, I think we can postpone this until further down the line.
