### PR TITLE
More robust handling of variadics in external

### DIFF
--- a/deeplay/external/external.py
+++ b/deeplay/external/external.py
@@ -40,10 +40,30 @@ class External(DeeplayModule):
         # Hack
         self.classtype = classtype
         super().__pre_init__(*args, classtype=classtype, **kwargs)
+        self.assert_not_positional_only_and_variadic()
 
     def __init__(self, classtype, *args, **kwargs):
         super().__init__()
         self.classtype = classtype
+        self.assert_not_positional_only_and_variadic()
+
+    def assert_not_positional_only_and_variadic(self):
+        argspec = self.get_argspec()
+        signature = self.get_signature()
+
+        positional_only_args = [
+            param
+            for param in signature.parameters.values()
+            if param.kind == param.POSITIONAL_ONLY
+        ]
+
+        has_variadic = argspec.varargs is not None
+
+        if positional_only_args and has_variadic:
+            raise TypeError(
+                f"Cannot use both positional only arguments and *args with {self.__class__.__name__}. Consider wrapping the classtype in a wrapper class."
+            )
+
 
     def build(self) -> nn.Module:
         kwargs = self.kwargs

--- a/deeplay/external/external.py
+++ b/deeplay/external/external.py
@@ -53,6 +53,17 @@ class External(DeeplayModule):
 
         # check if classtype has *args variadic
         argspec = self.get_argspec()
+        signature = self.get_signature()
+
+          
+        positional_only_args =[param.name
+                                for param in signature.parameters.values()
+                                if param.kind == param.POSITIONAL_ONLY]
+
+        # Any positional only arguments should be moved from kwargs to args
+        for arg in positional_only_args:
+            args = args + (kwargs.pop(arg),)
+
         if argspec.varargs is not None:
             args = args + self._actual_init_args["args"]
 

--- a/deeplay/tests/test_layer.py
+++ b/deeplay/tests/test_layer.py
@@ -15,6 +15,12 @@ class Container(dl.DeeplayModule):
         super().__init__()
         self.module = dl.Layer(nn.Identity)
 
+class VariadicClass:
+
+    def __init__(self, *args, **kwargs):
+        self._args = args
+        for key, value in kwargs.items():
+            setattr(self, key, value)
 
 class TestExternal(unittest.TestCase):
     def test_external(self):
@@ -91,3 +97,17 @@ class TestExternal(unittest.TestCase):
         wrapped = Wrapper(container)
 
         self.assertIsInstance(wrapped.module.module, nn.Identity)
+
+    def test_variadic(self):
+        external = dl.External(VariadicClass, 10, 20, arg=30)
+        built = external.build()
+        created = external.create()
+        self.assertIsInstance(created, VariadicClass)
+        self.assertIsInstance(built, VariadicClass)
+        self.assertIsNot(built, created)
+
+        self.assertEqual(built._args, (10, 20))
+        self.assertEqual(built.arg, 30)
+        
+        self.assertEqual(created._args, (10, 20))
+        self.assertEqual(created.arg, 30)

--- a/deeplay/tests/test_layer.py
+++ b/deeplay/tests/test_layer.py
@@ -164,21 +164,5 @@ class TestExternal(unittest.TestCase):
 
     def test_general_variadic(self):
 
-        external = dl.External(GeneralVariadicClass, 10, 20, 25, kw_only=30, kwonly_with_default=50, arg1=60)
-        built = external.build()
-        created = external.create()
-        self.assertIsInstance(created, GeneralVariadicClass)
-        self.assertIsInstance(built, GeneralVariadicClass)
-        self.assertIsNot(built, created)
-
-        self.assertEqual(built.pos_only, 10)
-        self.assertEqual(built.standard, 20)
-        self.assertEqual(built.kw_only, 30)
-        self.assertEqual(built.kwonly_with_default, 50)
-        self.assertEqual(built.arg1, 60)
-        
-        self.assertEqual(created.pos_only, 10)
-        self.assertEqual(created.standard, 20)
-        self.assertEqual(created.kw_only, 30)
-        self.assertEqual(created.kwonly_with_default, 50)
-        self.assertEqual(created.arg1, 60)
+        with self.assertRaises(TypeError):
+            external = dl.External(GeneralVariadicClass, 10, 20, 25, kw_only=30, kwonly_with_default=50)


### PR DESCRIPTION
Fixes an issue where classes with both *args and **kwargs in their signature could not be created using `Layer`.

There is only very rare case that is not supported, which is when you have both variadics and positionaal only arguments. Example:
```py

class MyOverlyComplexClass
    def __init__(self, posonly, /, param, *args):
        ...

layer = Layer(MyOverlyComplexClass, "foo", "bar", "baz")
```

Where we now throw a type error. Should be extremely rare (`/` is almost never used). But in these cases you can provide a wrapper like

```py

def overly_complex_builder(self, posonly, param, *args):
    return MyOverlyComplexClass(posonly, param, *args)

layer = Layer(overly_complex_builder, "foo", "bar", "baz")
```

