### PR TITLE
Fix LayerList slice mutation bug

### DIFF
--- a/deeplay/list.py
+++ b/deeplay/list.py
@@ -16,7 +16,6 @@ class LayerList(DeeplayModule, nn.ModuleList, Generic[T]):
         layers = tuple(input_layers) + _args
         super().__pre_init__(_args=layers)
 
-
     def __init__(self, *layers: T):
         super().__init__()
 
@@ -25,7 +24,7 @@ class LayerList(DeeplayModule, nn.ModuleList, Generic[T]):
 
         for idx, layer in enumerate(layers):
             super().append(layer)
-            if isinstance(layer, DeeplayModule):
+            if isinstance(layer, DeeplayModule) and not layer._has_built:
                 self._give_user_configuration(layer, self._get_abs_string_index(idx))
                 layer.__construct__()
 

--- a/deeplay/tests/test_layerlist.py
+++ b/deeplay/tests/test_layerlist.py
@@ -1,7 +1,7 @@
 import unittest
 import torch
 import torch.nn as nn
-from deeplay import LayerList, DeeplayModule, Layer
+from deeplay import LayerList, DeeplayModule, Layer, LayerActivation
 import itertools
 
 
@@ -164,3 +164,17 @@ class TestLayerList(unittest.TestCase):
         self.assertEqual(len(llist), 2)
         self.assertIsInstance(llist[0], nn.Linear)
         self.assertIsInstance(llist[1], nn.Linear)
+
+    def test_slice_does_not_mutate(self):
+        llist = LayerList(
+            LayerActivation(Layer(nn.Linear, 1, 1), Layer(nn.ReLU)),
+            LayerActivation(Layer(nn.Linear, 1, 1), Layer(nn.ReLU)),
+            LayerActivation(Layer(nn.Linear, 1, 1), Layer(nn.ReLU)),
+            LayerActivation(Layer(nn.Linear, 1, 1), Layer(nn.ReLU)),
+        )
+        llist.build()
+        llist[0:1]
+        for layer in llist:
+            self.assertTrue(layer._has_built)
+        for layer in llist[0:]:
+            self.assertTrue(layer._has_built)


### PR DESCRIPTION
Fixes an issue where slicing LayerList would mutate the elements (by calling `__construct__`). This PR changes this to only call `__construct__` if the layer is not already built.