### PR TITLE
Bm/on-build-descriptors

### DIFF
--- a/deeplay/__init__.py
+++ b/deeplay/__init__.py
@@ -8,6 +8,7 @@ from torch.utils.data import DataLoader
 # Filter out warnings from lazy torch modules
 warnings.filterwarnings("ignore", category=UserWarning, module="torch.nn.modules.lazy")
 
+
 from .meta import ExtendedConstructorMeta
 from .module import DeeplayModule
 from .list import LayerList, Sequential
@@ -15,3 +16,5 @@ from .external import *
 from .blocks import *
 from .components import *
 from .applications import *
+
+from . import decorators

--- a/deeplay/decorators.py
+++ b/deeplay/decorators.py
@@ -1,0 +1,29 @@
+from .module import DeeplayModule
+from functools import wraps
+
+
+def before_build(func):
+    """Decorator for methods that will be run before build instead of immediately."""
+
+    @wraps(func)
+    def wrapper(self: DeeplayModule, *args, **kwargs):
+        self.register_before_build_hook(
+            lambda instance: func(instance, *args, **kwargs)
+        )
+        return self
+
+    return wrapper
+
+
+def after_build(func):
+    """Decorator for methods that will be run after build instead of immediately.
+
+    If the build method creates a new object, the hook will run on the new object.
+    """
+
+    @wraps(func)
+    def wrapper(self: DeeplayModule, *args, **kwargs):
+        self.register_after_build_hook(lambda instance: func(instance, *args, **kwargs))
+        return self
+
+    return wrapper

--- a/deeplay/tests/test_decorators.py
+++ b/deeplay/tests/test_decorators.py
@@ -1,0 +1,128 @@
+import unittest
+
+from deeplay import DeeplayModule, External
+from deeplay.decorators import before_build, after_build
+from unittest.mock import Mock
+
+
+class DecoratedModule(DeeplayModule):
+    @before_build
+    def run_function_before_build(self, func):
+        func(self)
+
+    @after_build
+    def run_function_after_build(self, func):
+        func(self)
+
+
+class DecoratedExternal(External):
+    @before_build
+    def run_function_before_build(self, func):
+        func(self)
+
+    @after_build
+    def run_function_after_build(self, func):
+        func(self)
+
+
+class DummyClass:
+    ...
+
+
+class TestDecorators(unittest.TestCase):
+    def test_hooks_do_run(self):
+        before_build_mocks = [Mock() for _ in range(3)]
+        after_build_mocks = [Mock() for _ in range(3)]
+
+        module = DecoratedModule()
+
+        for mock in before_build_mocks:
+            module.run_function_before_build(mock)
+
+        for mock in after_build_mocks:
+            module.run_function_after_build(mock)
+
+        module.build()
+
+        for mock in before_build_mocks:
+            mock.assert_called_once_with(module)
+
+        for mock in after_build_mocks:
+            mock.assert_called_once_with(module)
+
+    def test_hooks_survive_new(self):
+        before_build_mocks = [Mock() for _ in range(3)]
+        after_build_mocks = [Mock() for _ in range(3)]
+
+        module = DecoratedModule()
+
+        for mock in before_build_mocks:
+            module.run_function_before_build(mock)
+
+        for mock in after_build_mocks:
+            module.run_function_after_build(mock)
+
+        new_module = module.new()
+
+        new_module.build()
+
+        for mock in before_build_mocks:
+            mock.assert_called_with(new_module)
+
+        for mock in after_build_mocks:
+            mock.assert_called_with(new_module)
+
+    def test_hooks_module(self):
+        module = DecoratedModule()
+
+        @module.run_function_before_build
+        def _before_build(mod):
+            self.assertFalse(mod._has_built)
+
+        @module.run_function_after_build
+        def _after_build(mod):
+            self.assertTrue(mod._has_built)
+
+        module.build()
+
+    def test_hooks_external_do_run(self):
+        before_build_mocks = [Mock() for _ in range(3)]
+        after_build_mocks = [Mock() for _ in range(3)]
+
+        external = DecoratedExternal(DummyClass)
+
+        for mock in before_build_mocks:
+            external.run_function_before_build(mock)
+
+        for mock in after_build_mocks:
+            external.run_function_after_build(mock)
+
+        built = external.build()
+
+        for mock in before_build_mocks:
+            mock.assert_called_once_with(external)
+
+        for mock in after_build_mocks:
+            mock.assert_called_once_with(built)
+
+    def test_hooks_external_survive_new(self):
+        before_build_mocks = [Mock() for _ in range(3)]
+        after_build_mocks = [Mock() for _ in range(3)]
+
+        external = DecoratedExternal(DummyClass)
+
+        for mock in before_build_mocks:
+            external.run_function_before_build(mock)
+
+        for mock in after_build_mocks:
+            external.run_function_after_build(mock)
+
+        new_external = external.new()
+
+        built = new_external.build()
+
+        for mock in before_build_mocks:
+            mock.assert_called_with(new_external)
+
+        for mock in after_build_mocks:
+            mock.assert_called_with(built)


### PR DESCRIPTION
Add some descriptors for methods that specify that those methods should be run on the build cycle. 

This is intended for developers. 

The main utility is that methods that live on the build life cycle are now guaranteed to operate on the final object. So these configurations are ensured to survive `.new()`. By default, only the operations done in `__init__` and `configure` survive `new`. 

In the future, it may be worth it to make `configure` such a hook as well.

Example:

```py
class MyModule(DeeplayModule)
    @after_build
    def set(self, name, value):
        setattr(self, name, value 

module = MyModule()
module.set("foo", 10)

module.foo # AttributeError

module.build()

module.foo # 10
``` 