### PR TITLE
Bm/set extras hooks

### DIFF
--- a/deeplay/external/layer.py
+++ b/deeplay/external/layer.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Type, overload
+from typing import Any, Type, overload, Dict
 from .external import External
 from functools import partial
 
@@ -7,7 +7,7 @@ import torch.nn as nn
 from ..decorators import after_build
 
 
-def _create_forward_with_extras(old_forward, extra_arguments: dict[str, str]):
+def _create_forward_with_extras(old_forward, extra_arguments: Dict[str, str]):
     def forward_with_extras(self, *args, extras={}, **kwargs):
         assert all(
             key not in kwargs for key in extra_arguments.keys()

--- a/deeplay/external/layer.py
+++ b/deeplay/external/layer.py
@@ -1,12 +1,51 @@
 from typing import Any, Callable, Type, overload
 from .external import External
+from functools import partial
 
 import torch.nn as nn
+
+from ..decorators import after_build
+
+
+def _create_forward_with_extras(old_forward, extra_arguments: dict[str, str]):
+    def forward_with_extras(self, *args, extras={}, **kwargs):
+        assert all(
+            key not in kwargs for key in extra_arguments.keys()
+        ), f"Cannot pass {extra_arguments.keys()} as keyword arguments. Use extras instead."
+
+        missing_extras = set(extra_arguments.values()) - set(extras.keys())
+        assert (
+            not missing_extras
+        ), f"module {self} did not receive the following extras: {missing_extras}"
+
+        my_extras = {key: extras[value] for key, value in extra_arguments.items()}
+        return old_forward(self, *args, **my_extras)
+
+    return forward_with_extras
 
 
 class Layer(External):
     def __pre_init__(self, classtype: Type[nn.Module], *args, **kwargs):
         super().__pre_init__(classtype, *args, **kwargs)
+
+    @after_build
+    def set_extras(layer: nn.Module, *args: str, **kwargs: str):
+        extras = {}
+
+        for arg in args:
+            extras[arg] = arg
+
+        extras.update(kwargs)
+
+        # monkey patch the forward method to include the extras
+        # using type(layer) to get the base implementation of forward.
+        # This is necessary so that multiple calls to set_extras don't
+        # chain the monkey patching.
+        # We use partial to bind the instance to make it a method.
+        layer.forward = partial(
+            _create_forward_with_extras(type(layer).forward, extras),
+            layer,
+        )
 
     @overload
     def configure(self, **kwargs: Any) -> None:

--- a/deeplay/tests/test_external.py
+++ b/deeplay/tests/test_external.py
@@ -10,6 +10,34 @@ class Wrapper(dl.DeeplayModule):
         self.module = module
 
 
+class VariadicClass:
+    def __init__(self, *args, **kwargs):
+        self._args = args
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+class KWVariadicClass:
+    def __init__(self, arg1, kwarg=2, **kwargs):
+        self.arg1 = arg1
+        self.kwarg = kwarg
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+class GeneralVariadicClass:
+    def __init__(
+        self, pos_only, /, standard, *args, kw_only, kwonly_with_default=60, **kwargs
+    ):
+        self.pos_only = pos_only
+        self.standard = standard
+        self.kw_only = kw_only
+        self.kwonly_with_default = kwonly_with_default
+        self._args = args
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
 class TestExternal(unittest.TestCase):
     def test_external(self):
         external = dl.External(nn.Identity)
@@ -45,3 +73,56 @@ class TestExternal(unittest.TestCase):
         self.assertIsInstance(created.module, nn.Sigmoid)
         self.assertIsInstance(built.module, nn.Sigmoid)
         self.assertIsNot(built.module, created.module)
+
+    def test_variadic(self):
+        external = dl.External(VariadicClass, 10, 20, arg=30)
+        built = external.build()
+        created = external.create()
+        self.assertIsInstance(created, VariadicClass)
+        self.assertIsInstance(built, VariadicClass)
+        self.assertIsNot(built, created)
+
+        self.assertEqual(built._args, (10, 20))
+        self.assertEqual(built.arg, 30)
+
+        self.assertEqual(created._args, (10, 20))
+        self.assertEqual(created.arg, 30)
+
+    def test_kwvariadic_1(self):
+        external = dl.External(KWVariadicClass, 5, kwarg=30, arg2=40)
+        external.configure(arg1=10)
+        built = external.build()
+        created = external.create()
+        self.assertIsInstance(created, KWVariadicClass)
+        self.assertIsInstance(built, KWVariadicClass)
+        self.assertIsNot(built, created)
+
+        self.assertEqual(built.arg1, 10)
+        self.assertEqual(built.kwarg, 30)
+        self.assertEqual(built.arg2, 40)
+
+        self.assertEqual(created.arg1, 10)
+        self.assertEqual(created.kwarg, 30)
+        self.assertEqual(created.arg2, 40)
+
+    def test_kwvariadic_2(self):
+        external = dl.External(KWVariadicClass, arg1=10, kwarg=30, arg2=40)
+        built = external.build()
+        created = external.create()
+        self.assertIsInstance(created, KWVariadicClass)
+        self.assertIsInstance(built, KWVariadicClass)
+        self.assertIsNot(built, created)
+
+        self.assertEqual(built.arg1, 10)
+        self.assertEqual(built.kwarg, 30)
+        self.assertEqual(built.arg2, 40)
+
+        self.assertEqual(created.arg1, 10)
+        self.assertEqual(created.kwarg, 30)
+        self.assertEqual(created.arg2, 40)
+
+    def test_general_variadic(self):
+        with self.assertRaises(TypeError):
+            external = dl.External(
+                GeneralVariadicClass, 10, 20, 25, kw_only=30, kwonly_with_default=50
+            )

--- a/deeplay/tests/test_layer.py
+++ b/deeplay/tests/test_layer.py
@@ -1,7 +1,10 @@
 import unittest
 
 import deeplay as dl
+import torch
 import torch.nn as nn
+
+from unittest.mock import Mock
 
 
 class Wrapper(dl.DeeplayModule):
@@ -15,31 +18,8 @@ class Container(dl.DeeplayModule):
         super().__init__()
         self.module = dl.Layer(nn.Identity)
 
-class VariadicClass:
-    def __init__(self, *args, **kwargs):
-        self._args = args
-        for key, value in kwargs.items():
-            setattr(self, key, value)
 
-class KWVariadicClass:
-    def __init__(self, arg1, kwarg=2, **kwargs):
-        self.arg1 = arg1
-        self.kwarg = kwarg
-        for key, value in kwargs.items():
-            setattr(self, key, value)
-
-
-class GeneralVariadicClass:
-    def __init__(self, pos_only, /, standard, *args, kw_only, kwonly_with_default=60, **kwargs):
-        self.pos_only = pos_only
-        self.standard = standard
-        self.kw_only = kw_only
-        self.kwonly_with_default = kwonly_with_default
-        self._args = args
-        for key, value in kwargs.items():  
-            setattr(self, key, value)
-
-class TestExternal(unittest.TestCase):
+class TestLayer(unittest.TestCase):
     def test_external(self):
         external = dl.Layer(nn.Identity)
         built = external.build()
@@ -115,54 +95,29 @@ class TestExternal(unittest.TestCase):
 
         self.assertIsInstance(wrapped.module.module, nn.Identity)
 
-    def test_variadic(self):
-        external = dl.External(VariadicClass, 10, 20, arg=30)
+    def test_set_extras(self):
+        class SimpleModule(nn.Module):
+            def forward(self, x, extra1, extra2):
+                extra1()
+                extra2()
+                return x
+
+        external = dl.Layer(SimpleModule)
+        external.set_extras("extra1", extra2="other_name")
         built = external.build()
-        created = external.create()
-        self.assertIsInstance(created, VariadicClass)
-        self.assertIsInstance(built, VariadicClass)
-        self.assertIsNot(built, created)
 
-        self.assertEqual(built._args, (10, 20))
-        self.assertEqual(built.arg, 30)
-        
-        self.assertEqual(created._args, (10, 20))
-        self.assertEqual(created.arg, 30)
+        built
 
-    def test_kwvariadic_1(self):
-        external = dl.External(KWVariadicClass, 5, kwarg=30, arg2=40)
-        external.configure(arg1=10)
-        built = external.build()
-        created = external.create()
-        self.assertIsInstance(created, KWVariadicClass)
-        self.assertIsInstance(built, KWVariadicClass)
-        self.assertIsNot(built, created)
+        all_extras = {
+            "extra1": Mock(),
+            "other_name": Mock(),
+            "extra2": Mock(),
+            "unrelated": Mock(),
+        }
 
-        self.assertEqual(built.arg1, 10)
-        self.assertEqual(built.kwarg, 30)
-        self.assertEqual(built.arg2, 40)
-        
-        self.assertEqual(created.arg1, 10)
-        self.assertEqual(created.kwarg, 30)
-        self.assertEqual(created.arg2, 40)
-    
-    def test_kwvariadic_2(self):
-        external = dl.External(KWVariadicClass, arg1=10, kwarg=30, arg2=40)
-        built = external.build()
-        created = external.create()
-        self.assertIsInstance(created, KWVariadicClass)
-        self.assertIsInstance(built, KWVariadicClass)
-        self.assertIsNot(built, created)
+        built(torch.randn(10, 10), extras=all_extras)
 
-        self.assertEqual(built.arg1, 10)
-        self.assertEqual(built.kwarg, 30)
-        self.assertEqual(built.arg2, 40)
-        
-        self.assertEqual(created.arg1, 10)
-        self.assertEqual(created.kwarg, 30)
-        self.assertEqual(created.arg2, 40)
-
-    def test_general_variadic(self):
-
-        with self.assertRaises(TypeError):
-            external = dl.External(GeneralVariadicClass, 10, 20, 25, kw_only=30, kwonly_with_default=50)
+        all_extras["extra1"].assert_called_once()
+        all_extras["other_name"].assert_called_once()
+        all_extras["extra2"].assert_not_called()
+        all_extras["unrelated"].assert_not_called()


### PR DESCRIPTION
This PR adds `set_extras` as a hook to Layer. This hook monkey-patches the forward method of the final instance of the layer to correctly map extra arguments in the forward call to the ones expected by the class.

This is necessary in case one swaps a layer to another that has another call signature. This is the first step in a larger design addition where modules can define extra data that layers can pull from if needed. 