### PR TITLE
Implement replace method

### DIFF
--- a/deeplay/__init__.py
+++ b/deeplay/__init__.py
@@ -8,6 +8,7 @@ from torch.utils.data import DataLoader
 # Filter out warnings from lazy torch modules
 warnings.filterwarnings("ignore", category=UserWarning, module="torch.nn.modules.lazy")
 
+
 from .meta import ExtendedConstructorMeta
 from .module import DeeplayModule
 from .list import LayerList, Sequential
@@ -15,3 +16,5 @@ from .external import *
 from .blocks import *
 from .components import *
 from .applications import *
+
+from . import decorators

--- a/deeplay/decorators.py
+++ b/deeplay/decorators.py
@@ -1,0 +1,29 @@
+from .module import DeeplayModule
+from functools import wraps
+
+
+def before_build(func):
+    """Decorator for methods that will be run before build instead of immediately."""
+
+    @wraps(func)
+    def wrapper(self: DeeplayModule, *args, **kwargs):
+        self.register_before_build_hook(
+            lambda instance: func(instance, *args, **kwargs)
+        )
+        return self
+
+    return wrapper
+
+
+def after_build(func):
+    """Decorator for methods that will be run after build instead of immediately.
+
+    If the build method creates a new object, the hook will run on the new object.
+    """
+
+    @wraps(func)
+    def wrapper(self: DeeplayModule, *args, **kwargs):
+        self.register_after_build_hook(lambda instance: func(instance, *args, **kwargs))
+        return self
+
+    return wrapper

--- a/deeplay/decorators.py
+++ b/deeplay/decorators.py
@@ -1,4 +1,3 @@
-from .module import DeeplayModule
 from functools import wraps
 
 
@@ -6,7 +5,7 @@ def before_build(func):
     """Decorator for methods that will be run before build instead of immediately."""
 
     @wraps(func)
-    def wrapper(self: DeeplayModule, *args, **kwargs):
+    def wrapper(self, *args, **kwargs):
         self.register_before_build_hook(
             lambda instance: func(instance, *args, **kwargs)
         )
@@ -22,7 +21,7 @@ def after_build(func):
     """
 
     @wraps(func)
-    def wrapper(self: DeeplayModule, *args, **kwargs):
+    def wrapper(self, *args, **kwargs):
         self.register_after_build_hook(lambda instance: func(instance, *args, **kwargs))
         return self
 

--- a/deeplay/module.py
+++ b/deeplay/module.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Tuple, List, Set
 import torch.nn as nn
 
 from .meta import ExtendedConstructorMeta, not_top_level
+from .decorators import before_build
 
 
 class DeeplayModule(nn.Module, metaclass=ExtendedConstructorMeta):
@@ -142,6 +143,42 @@ class DeeplayModule(nn.Module, metaclass=ExtendedConstructorMeta):
 
     def __post_init__(self):
         ...
+
+    @before_build
+    def replace(self, target: str, replacement: nn.Module):
+        """
+        Replaces a child module with another module.
+
+        This method replaces the child module with the given name with the specified replacement module.
+        It is useful for dynamically swapping out modules within a larger module or for replacing
+        modules within a module that has already been built.
+
+        Parameters
+        ----------
+        target : str
+            The name of the child module to be replaced.
+        replacement : DeeplayModule
+            The replacement module.
+
+        Raises
+        ------
+        ValueError
+            Raised if the target module is not found among the module's children.
+
+        Example Usage
+        -------------
+        To replace a child module with another module:
+        ```
+        module = ExampleModule()
+        module.replace('child_module', ReplacementModule())
+        ```
+        """
+        if target not in self._modules:
+            raise ValueError(
+                f"Cannot replace {target}. {target} is not a child module of {self.__class__.__name__}."
+            )
+
+        self._modules[target] = replacement
 
     def configure(self, *args: Any, **kwargs: Any):
         """

--- a/deeplay/tests/test_decorators.py
+++ b/deeplay/tests/test_decorators.py
@@ -1,0 +1,128 @@
+import unittest
+
+from deeplay import DeeplayModule, External
+from deeplay.decorators import before_build, after_build
+from unittest.mock import Mock
+
+
+class DecoratedModule(DeeplayModule):
+    @before_build
+    def run_function_before_build(self, func):
+        func(self)
+
+    @after_build
+    def run_function_after_build(self, func):
+        func(self)
+
+
+class DecoratedExternal(External):
+    @before_build
+    def run_function_before_build(self, func):
+        func(self)
+
+    @after_build
+    def run_function_after_build(self, func):
+        func(self)
+
+
+class DummyClass:
+    ...
+
+
+class TestDecorators(unittest.TestCase):
+    def test_hooks_do_run(self):
+        before_build_mocks = [Mock() for _ in range(3)]
+        after_build_mocks = [Mock() for _ in range(3)]
+
+        module = DecoratedModule()
+
+        for mock in before_build_mocks:
+            module.run_function_before_build(mock)
+
+        for mock in after_build_mocks:
+            module.run_function_after_build(mock)
+
+        module.build()
+
+        for mock in before_build_mocks:
+            mock.assert_called_once_with(module)
+
+        for mock in after_build_mocks:
+            mock.assert_called_once_with(module)
+
+    def test_hooks_survive_new(self):
+        before_build_mocks = [Mock() for _ in range(3)]
+        after_build_mocks = [Mock() for _ in range(3)]
+
+        module = DecoratedModule()
+
+        for mock in before_build_mocks:
+            module.run_function_before_build(mock)
+
+        for mock in after_build_mocks:
+            module.run_function_after_build(mock)
+
+        new_module = module.new()
+
+        new_module.build()
+
+        for mock in before_build_mocks:
+            mock.assert_called_with(new_module)
+
+        for mock in after_build_mocks:
+            mock.assert_called_with(new_module)
+
+    def test_hooks_module(self):
+        module = DecoratedModule()
+
+        @module.run_function_before_build
+        def _before_build(mod):
+            self.assertFalse(mod._has_built)
+
+        @module.run_function_after_build
+        def _after_build(mod):
+            self.assertTrue(mod._has_built)
+
+        module.build()
+
+    def test_hooks_external_do_run(self):
+        before_build_mocks = [Mock() for _ in range(3)]
+        after_build_mocks = [Mock() for _ in range(3)]
+
+        external = DecoratedExternal(DummyClass)
+
+        for mock in before_build_mocks:
+            external.run_function_before_build(mock)
+
+        for mock in after_build_mocks:
+            external.run_function_after_build(mock)
+
+        built = external.build()
+
+        for mock in before_build_mocks:
+            mock.assert_called_once_with(external)
+
+        for mock in after_build_mocks:
+            mock.assert_called_once_with(built)
+
+    def test_hooks_external_survive_new(self):
+        before_build_mocks = [Mock() for _ in range(3)]
+        after_build_mocks = [Mock() for _ in range(3)]
+
+        external = DecoratedExternal(DummyClass)
+
+        for mock in before_build_mocks:
+            external.run_function_before_build(mock)
+
+        for mock in after_build_mocks:
+            external.run_function_after_build(mock)
+
+        new_external = external.new()
+
+        built = new_external.build()
+
+        for mock in before_build_mocks:
+            mock.assert_called_with(new_external)
+
+        for mock in after_build_mocks:
+            mock.assert_called_with(built)

--- a/deeplay/tests/test_layer.py
+++ b/deeplay/tests/test_layer.py
@@ -15,11 +15,13 @@ class Container(dl.DeeplayModule):
         super().__init__()
         self.module = dl.Layer(nn.Identity)
 
+
 class VariadicClass:
     def __init__(self, *args, **kwargs):
         self._args = args
         for key, value in kwargs.items():
             setattr(self, key, value)
+
 
 class KWVariadicClass:
     def __init__(self, arg1, kwarg=2, **kwargs):
@@ -30,14 +32,17 @@ class KWVariadicClass:
 
 
 class GeneralVariadicClass:
-    def __init__(self, pos_only, /, standard, *args, kw_only, kwonly_with_default=60, **kwargs):
+    def __init__(
+        self, pos_only, /, standard, *args, kw_only, kwonly_with_default=60, **kwargs
+    ):
         self.pos_only = pos_only
         self.standard = standard
         self.kw_only = kw_only
         self.kwonly_with_default = kwonly_with_default
         self._args = args
-        for key, value in kwargs.items():  
+        for key, value in kwargs.items():
             setattr(self, key, value)
+
 
 class TestExternal(unittest.TestCase):
     def test_external(self):
@@ -125,7 +130,7 @@ class TestExternal(unittest.TestCase):
 
         self.assertEqual(built._args, (10, 20))
         self.assertEqual(built.arg, 30)
-        
+
         self.assertEqual(created._args, (10, 20))
         self.assertEqual(created.arg, 30)
 
@@ -141,11 +146,11 @@ class TestExternal(unittest.TestCase):
         self.assertEqual(built.arg1, 10)
         self.assertEqual(built.kwarg, 30)
         self.assertEqual(built.arg2, 40)
-        
+
         self.assertEqual(created.arg1, 10)
         self.assertEqual(created.kwarg, 30)
         self.assertEqual(created.arg2, 40)
-    
+
     def test_kwvariadic_2(self):
         external = dl.External(KWVariadicClass, arg1=10, kwarg=30, arg2=40)
         built = external.build()
@@ -157,12 +162,13 @@ class TestExternal(unittest.TestCase):
         self.assertEqual(built.arg1, 10)
         self.assertEqual(built.kwarg, 30)
         self.assertEqual(built.arg2, 40)
-        
+
         self.assertEqual(created.arg1, 10)
         self.assertEqual(created.kwarg, 30)
         self.assertEqual(created.arg2, 40)
 
     def test_general_variadic(self):
-
         with self.assertRaises(TypeError):
-            external = dl.External(GeneralVariadicClass, 10, 20, 25, kw_only=30, kwonly_with_default=50)
+            external = dl.External(
+                GeneralVariadicClass, 10, 20, 25, kw_only=30, kwonly_with_default=50
+            )

--- a/deeplay/tests/test_module.py
+++ b/deeplay/tests/test_module.py
@@ -1,4 +1,6 @@
 import unittest
+
+import torch
 import torch.nn as nn
 import deeplay as dl
 
@@ -236,9 +238,6 @@ class TestDeeplayModule(unittest.TestCase):
         self.assertEqual(parent.foo.bar.a, 7)
         self.assertEqual(parent.foo.bar.b, 8)
         self.assertEqual(parent.foo.bar.c, "F")
-
-
-import torch
 
 
 class ModelWithLayer(dl.DeeplayModule):

--- a/deeplay/tests/test_module.py
+++ b/deeplay/tests/test_module.py
@@ -2,6 +2,18 @@ import unittest
 import torch.nn as nn
 import deeplay as dl
 
+from deeplay import (
+    DeeplayModule,
+)  # Import your actual module here
+
+
+# A simple subclass for testing
+class TestModule(DeeplayModule):
+    def __init__(self, param1=None, param2=None):
+        super().__init__()
+        self.param1 = param1
+        self.param2 = param2
+
 
 class DummyClass:
     def __init__(self, a, b, c):
@@ -28,6 +40,49 @@ class Module2(dl.DeeplayModule):
 
 
 class TestDeeplayModule(unittest.TestCase):
+    def test_initialization(self):
+        # Testing basic initialization and attribute setting
+        module = TestModule(param1=10, param2="test")
+        self.assertEqual(module.param1, 10)
+        self.assertEqual(module.param2, "test")
+
+    def test_configure(self):
+        # Testing the configure method
+        module = TestModule()
+        module.configure("param1", 20)
+        module.configure(param2="configured")
+        self.assertEqual(module.param1, 20)
+        self.assertEqual(module.param2, "configured")
+
+    def test_build(self):
+        # Testing the build method
+        module = TestModule()
+        module.configure(param1=30)
+        built_module = module.build()
+        self.assertEqual(built_module.param1, 30)
+        self.assertTrue(built_module._has_built)
+
+    def test_create(self):
+        # Testing the create method
+        module = TestModule(param1=40)
+        new_module = module.create()
+        self.assertIsInstance(new_module, TestModule)
+        self.assertEqual(new_module.param1, 40)
+        self.assertNotEqual(new_module, module)
+
+    def test_get_user_configuration(self):
+        # Testing retrieval of user configuration
+        module = TestModule(param1=50)
+        module.configure(param1=60)
+        config = module.get_user_configuration()
+        self.assertEqual(config[("param1",)], 60)
+
+    def test_invalid_configure(self):
+        # Testing configure method with invalid attribute
+        module = TestModule()
+        with self.assertRaises(ValueError):
+            module.configure("invalid_param", 100)
+
     def test_configure_1(self):
         module = Module()
         module.configure(a=1)
@@ -104,10 +159,8 @@ class TestDeeplayModule(unittest.TestCase):
         module = Module2(Module())
         module.build()
 
-        module.configure("bar", a=3, b=4, c="D")
-        self.assertEqual(module.bar.a, 3)
-        self.assertEqual(module.bar.b, 4)
-        self.assertEqual(module.bar.c, "D")
+        with self.assertRaises(RuntimeError):
+            module.configure("foo", a=1, b=2, c="C")
 
     def test_init_2(self):
         module = Module(a=1, b=2, c="C")
@@ -141,7 +194,7 @@ class TestDeeplayModule(unittest.TestCase):
         self.assertEqual(created.foo.b, 2)
         self.assertEqual(created.foo.c, "C")
 
-        parent.child.configure(a=3)
+        parent.foo.configure(a=3)
 
         created_2 = parent.create()
 
@@ -152,9 +205,40 @@ class TestDeeplayModule(unittest.TestCase):
 
         self.assertIsNot(created.foo, created_2.foo)
 
+    def test_replace_1(self):
+        parent = Module2(foo=Module(a=1, b=2, c="C"))
+        parent.replace("foo", Module(a=3, b=4, c="D"))
+        parent.replace("bar", Module(a=5, b=6, c="E"))
+        parent.build()
+
+        self.assertEqual(parent.foo.a, 3)
+        self.assertEqual(parent.foo.b, 4)
+        self.assertEqual(parent.foo.c, "D")
+
+        self.assertEqual(parent.bar.a, 5)
+        self.assertEqual(parent.bar.b, 6)
+        self.assertEqual(parent.bar.c, "E")
+
+    def test_replace_2(self):
+        parent = Module2(foo=Module(a=1, b=2, c="C"))
+
+        new_child = Module2(foo=Module(a=3, b=4, c="D"))
+        new_child.foo.configure(a=5, b=6, c="E")
+        new_child.replace("bar", Module(a=7, b=8, c="F"))
+
+        parent.replace("foo", new_child)
+        parent.build()
+
+        self.assertEqual(parent.foo.foo.a, 5)
+        self.assertEqual(parent.foo.foo.b, 6)
+        self.assertEqual(parent.foo.foo.c, "E")
+
+        self.assertEqual(parent.foo.bar.a, 7)
+        self.assertEqual(parent.foo.bar.b, 8)
+        self.assertEqual(parent.foo.bar.c, "F")
+
 
 import torch
-import torch.nn as nn
 
 
 class ModelWithLayer(dl.DeeplayModule):
@@ -245,71 +329,6 @@ class TestLayer(unittest.TestCase):
         model.build()
 
         self.assertEqual(model.foo.num_features, 20)
-
-
-import unittest
-from unittest.mock import Mock, patch
-from deeplay import (
-    DeeplayModule,
-)  # Import your actual module here
-
-import unittest
-from deeplay import DeeplayModule, ExtendedConstructorMeta
-import torch.nn as nn
-
-
-# A simple subclass for testing
-class TestModule(DeeplayModule):
-    def __init__(self, param1=None, param2=None):
-        super().__init__()
-        self.param1 = param1
-        self.param2 = param2
-
-
-# Unit tests for DeeplayModule
-class TestDeeplayModule(unittest.TestCase):
-    def test_initialization(self):
-        # Testing basic initialization and attribute setting
-        module = TestModule(param1=10, param2="test")
-        self.assertEqual(module.param1, 10)
-        self.assertEqual(module.param2, "test")
-
-    def test_configure(self):
-        # Testing the configure method
-        module = TestModule()
-        module.configure("param1", 20)
-        module.configure(param2="configured")
-        self.assertEqual(module.param1, 20)
-        self.assertEqual(module.param2, "configured")
-
-    def test_build(self):
-        # Testing the build method
-        module = TestModule()
-        module.configure(param1=30)
-        built_module = module.build()
-        self.assertEqual(built_module.param1, 30)
-        self.assertTrue(built_module._has_built)
-
-    def test_create(self):
-        # Testing the create method
-        module = TestModule(param1=40)
-        new_module = module.create()
-        self.assertIsInstance(new_module, TestModule)
-        self.assertEqual(new_module.param1, 40)
-        self.assertNotEqual(new_module, module)
-
-    def test_get_user_configuration(self):
-        # Testing retrieval of user configuration
-        module = TestModule(param1=50)
-        module.configure(param1=60)
-        config = module.get_user_configuration()
-        self.assertEqual(config[("param1",)], 60)
-
-    def test_invalid_configure(self):
-        # Testing configure method with invalid attribute
-        module = TestModule()
-        with self.assertRaises(ValueError):
-            module.configure("invalid_param", 100)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements the `replace` method. Used to make in-place swaps of modules. So,

```py

class MyModel(DeeplayModule):    
    def __init__(self):
        self.backbone = ConvolutionalNeuralNetwork(3, [32, 64], 128)
        self.head = MultiLayerPerceptron(None, [32, 32], 2)

model = MyModel()
model.replace("backbone", ResNet50().backbone)
model.build()
```

## Note

Currently, the replace does not happen until `.build()` is called. We could evaluate the replace immediately _and_ just before `build()`. It's unclear to me if this will cause problems in the future.