### PR TITLE
Clarify forward method error message

### DIFF
--- a/deeplay/external/layer.py
+++ b/deeplay/external/layer.py
@@ -20,5 +20,5 @@ class Layer(External):
 
     def forward(self, x):
         raise RuntimeError(
-            "Unexpected call to forward. Did you forget to `create` or `build`?"
+            "Unexpected call to forward. Did you forget to call `.build()` or `.create()` on the model?"
         )


### PR DESCRIPTION
Update the error message on calling forward on a Layer that has not been built to more clearly state that `build` and `create` are methods that should be called on the model.