### PR TITLE
Update CNN

### DIFF
--- a/deeplay/components/cnn/cnn.py
+++ b/deeplay/components/cnn/cnn.py
@@ -171,7 +171,7 @@ class ConvolutionalNeuralNetwork(DeeplayModule):
             activation = (
                 Layer(nn.ReLU) if i < len(self.hidden_channels) else out_activation
             )
-            normalization = Layer(nn.Identity, num_features=out_channels)
+            normalization = Layer(nn.Identity, num_features=c_out)
 
             block = PoolLayerActivationNormalization(
                 pool=pool_layer,


### PR DESCRIPTION
This pull request addresses a minor bug found in the default definition of a convolutional neural network (CNN). While this bug didn't impact the actual performance of the model, it led to confusion during model printing.