### PR TITLE
Remove *args and **kwargs names passed to init

### DIFF
--- a/deeplay/external/external.py
+++ b/deeplay/external/external.py
@@ -88,6 +88,15 @@ class External(DeeplayModule):
         if argspec.varargs is not None:
             args = args + self._actual_init_args["args"]
 
+        # Remove *args and **kwargs from kwargs
+        for key in list(kwargs.keys()):
+            if key in signature.parameters and (
+                signature.parameters[key].kind == signature.parameters[key].VAR_KEYWORD
+                or signature.parameters[key].kind
+                == signature.parameters[key].VAR_POSITIONAL
+            ):
+                kwargs.pop(key)
+
         obj = self.classtype(*args, **kwargs)
 
         self._run_hooks("after_build", obj)

--- a/deeplay/tests/test_layer.py
+++ b/deeplay/tests/test_layer.py
@@ -134,6 +134,11 @@ class TestExternal(unittest.TestCase):
         self.assertEqual(created._args, (10, 20))
         self.assertEqual(created.arg, 30)
 
+        self.assertFalse(hasattr(built, "args"))
+        self.assertFalse(hasattr(created, "args"))
+        self.assertFalse(hasattr(built, "kwargs"))
+        self.assertFalse(hasattr(created, "kwargs"))
+
     def test_kwvariadic_1(self):
         external = dl.External(KWVariadicClass, 5, kwarg=30, arg2=40)
         external.configure(arg1=10)


### PR DESCRIPTION
This PR fixes an issue where *args and **kwargs were added as keyword arguments args=..., kwargs=... during build. This caused the issue where
```py
layer = dl.Layer(torch.nn.LSTM, 10, 20, 2)
layer.build()
```

would throw an error complaining about an extra argument "args".