### PR TITLE
Fix configuration validation in DeeplayModule

### DIFF
--- a/deeplay/external/external.py
+++ b/deeplay/external/external.py
@@ -131,6 +131,11 @@ class External(DeeplayModule):
 
         super().configure(**kwargs)
 
+    def _assert_valid_configurable(self, *args):
+        if self.get_argspec().varkw is not None:
+            return
+        return super()._assert_valid_configurable(*args)
+
     def __repr__(self):
         classkwargs = ", ".join(
             f"{key}={value}" for key, value in self.kwargs.items() if key != "classtype"

--- a/deeplay/module.py
+++ b/deeplay/module.py
@@ -237,11 +237,7 @@ class DeeplayModule(nn.Module, metaclass=ExtendedConstructorMeta):
             self._configure_kwargs(kwargs)
 
         else:
-            if args[0] not in self.configurables:
-                raise ValueError(
-                    f"Unknown configurable {args[0]} for {self.__class__.__name__}. "
-                    f"Available configurables are {self.configurables}."
-                )
+            self._assert_valid_configurable(args[0])
 
             if hasattr(getattr(self, args[0]), "configure"):
                 getattr(self, args[0]).configure(*args[1:], **kwargs)
@@ -420,10 +416,7 @@ class DeeplayModule(nn.Module, metaclass=ExtendedConstructorMeta):
 
     def _configure_kwargs(self, kwargs):
         for name, value in kwargs.items():
-            if name not in self.configurables:
-                raise ValueError(
-                    f"Unknown configurable {name} for {self.__class__.__name__}. Available configurables are {self.configurables}."
-                )
+            self._assert_valid_configurable(name)
             self._user_config[(name,)] = value
         self.__construct__()
 
@@ -485,6 +478,13 @@ class DeeplayModule(nn.Module, metaclass=ExtendedConstructorMeta):
 
         arguments.pop("self", None)
         return arguments
+
+    def _assert_valid_configurable(self, *args):
+        if args[0] not in self.configurables:
+            raise ValueError(
+                f"Unknown configurable {args[0]} for {self.__class__.__name__}. "
+                f"Available configurables are {self.configurables}."
+            )
 
     def _run_hooks(self, hook_name, instance=None):
         if instance is None:

--- a/deeplay/tests/test_layer.py
+++ b/deeplay/tests/test_layer.py
@@ -172,3 +172,16 @@ class TestExternal(unittest.TestCase):
             external = dl.External(
                 GeneralVariadicClass, 10, 20, 25, kw_only=30, kwonly_with_default=50
             )
+
+    def test_configure_variadic(self):
+        external = dl.External(VariadicClass, 10, 20, arg=30)
+        external.configure(arg9=40)
+        built = external.build()
+        created = external.create()
+        self.assertIsInstance(created, VariadicClass)
+        self.assertIsInstance(built, VariadicClass)
+        self.assertIsNot(built, created)
+
+        self.assertEqual(built._args, (10, 20))
+        self.assertEqual(built.arg, 30)
+        self.assertEqual(built.arg9, 40)

--- a/deeplay/tests/test_module.py
+++ b/deeplay/tests/test_module.py
@@ -283,9 +283,9 @@ class TestLayer(unittest.TestCase):
             layer.configure(missdefined=10)
 
     def test_configure_4(self):
-        layer = dl.Layer(nn.Identity)
+        layer = dl.Layer(nn.Conv2d)
         with self.assertRaises(ValueError):
-            layer.configure(nn.Identity, num_features=20)
+            layer.configure(num_features=20)
 
     def test_forward(self):
         layer = dl.Layer(nn.BatchNorm1d, num_features=10)


### PR DESCRIPTION
Fixes an issue with `Layer` where classes with `**kwarg` signatures could only be configured with names given on initial construction. For example

```py
layer = dl.Layer(torch.nn.LSTM, input_size=10, hidden_size=20, num_layers=2)
layer.configure(bidirectional=True)
layer.build()
```
would not recognize `bidirectional` as a valid configurable. Now, we allow any keyword configurable as if the class has `**kwargs` in it's signature.