### PR TITLE
@after_init decorator with implementation

### DIFF
--- a/deeplay/blocks/block.py
+++ b/deeplay/blocks/block.py
@@ -16,9 +16,7 @@ from ..module import DeeplayModule
 T = TypeVar("T")
 
 
-class Block(
-    DeeplayModule,
-):
+class Block(DeeplayModule):
     @property
     def configurables(self):
         return super().configurables.union(self.kwargs.keys())

--- a/deeplay/decorators.py
+++ b/deeplay/decorators.py
@@ -26,3 +26,22 @@ def after_build(func):
         return self
 
     return wrapper
+
+
+def after_init(func):
+    """Decorator for methods that will be run after init _and_ immediately.
+
+    If called during init, the hook will not be stored and will only run immediately.
+    """
+
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        func(self, *args, **kwargs)
+
+        if not self._is_constructing:
+            self.register_after_init_hook(
+                lambda instance: func(instance, *args, **kwargs)
+            )
+        return self
+
+    return wrapper

--- a/deeplay/list.py
+++ b/deeplay/list.py
@@ -2,7 +2,7 @@ from typing import Any, overload, Iterator, List, Generic, TypeVar, Union, Tuple
 
 from torch import nn
 from .module import DeeplayModule
-
+from .decorators import after_init
 
 T = TypeVar("T", bound=nn.Module)
 
@@ -28,23 +28,34 @@ class LayerList(DeeplayModule, nn.ModuleList, Generic[T]):
                 self._give_user_configuration(layer, self._get_abs_string_index(idx))
                 layer.__construct__()
 
+    @after_init
     def append(self, module: DeeplayModule) -> "LayerList[T]":
-        if not self._has_built:
-            self._args = (*self._args, module)
-            self.__construct__()
-
-        else:
-            super().append(module)
-
+        super().append(module)
         return self
 
-    def pop(self, index: int = -1) -> T:
-        args = list(self._args)
-        args.pop(index)
-        self._args = tuple(args)
-        self.__construct__()
+    @after_init
+    def pop(self, key: int = -1) -> T:
+        return super().pop(key)
 
-        return self[index]
+    @after_init
+    def insert(self, index: int, module: DeeplayModule) -> "LayerList[T]":
+        super().insert(index, module)
+        return self
+
+    @after_init
+    def extend(self, modules: List[DeeplayModule]) -> "LayerList[T]":
+        super().extend(modules)
+        return self
+
+    @after_init
+    def remove(self, module: DeeplayModule) -> "LayerList[T]":
+        super().remove(module)
+        return self
+
+    @after_init
+    def reverse(self) -> "LayerList[T]":
+        super().reverse()
+        return self
 
     @overload
     def configure(

--- a/deeplay/meta.py
+++ b/deeplay/meta.py
@@ -20,10 +20,10 @@ class ExtendedConstructorMeta(type):
         if __user_config is not None:
             obj._user_config = __user_config
 
-        if cls._is_top_level["value"]:
-            with not_top_level(cls):
-                obj.__construct__()
-                obj.__post_init__()
+        # if cls._is_top_level["value"]:
+        with not_top_level(cls):
+            obj.__construct__()
+            obj.__post_init__()
 
         return obj
 

--- a/deeplay/module.py
+++ b/deeplay/module.py
@@ -130,6 +130,7 @@ class DeeplayModule(nn.Module, metaclass=ExtendedConstructorMeta):
         self._hooks = {
             "before_build": [],
             "after_build": [],
+            "after_init": [],
         }
 
         self._has_built = False
@@ -387,6 +388,20 @@ class DeeplayModule(nn.Module, metaclass=ExtendedConstructorMeta):
 
         self._hooks["after_build"].append(func)
 
+    def register_after_init_hook(self, func):
+        """
+        Registers a function to be called after the module is initialized.
+
+        Parameters
+        ----------
+        func : Callable
+            The function to be called after the module is initialized. The function should take
+            a single argument, which is the module instance.
+
+        """
+
+        self._hooks["after_init"].append(func)
+
     def get_user_configuration(self):
         """
         Retrieves the current user configuration of the module.
@@ -498,6 +513,7 @@ class DeeplayModule(nn.Module, metaclass=ExtendedConstructorMeta):
             self._is_constructing = True
             self.__init__(*self._args, **self.kwargs)
             self._is_constructing = False
+            self._run_hooks("after_init")
             self.__post_init__()
 
     @classmethod

--- a/deeplay/module.py
+++ b/deeplay/module.py
@@ -508,12 +508,13 @@ class DeeplayModule(nn.Module, metaclass=ExtendedConstructorMeta):
             hook(instance)
 
     def __construct__(self):
-        # with not_top_level(ExtendedConstructorMeta):
-        self._modules.clear()
-        self._is_constructing = True
-        self.__init__(*self._args, **self.kwargs)
-        self._is_constructing = False
-        self.__post_init__()
+        with not_top_level(ExtendedConstructorMeta):
+            self._modules.clear()
+            self._is_constructing = True
+            self.__init__(*self._args, **self.kwargs)
+            self._is_constructing = False
+            self._run_hooks("after_init")
+            self.__post_init__()
 
     @classmethod
     def get_argspec(cls):

--- a/deeplay/tests/test_layerlist.py
+++ b/deeplay/tests/test_layerlist.py
@@ -52,6 +52,7 @@ class TestLayerList(unittest.TestCase):
     def test_create_list(self):
         for Wrapper in [Wrapper1, Wrapper2, Wrapper3]:
             module = Wrapper(5)
+            self.assertEqual(len(module.layers), 5, Wrapper)
             module.build()
             self.assertEqual(len(module.layers), 5, Wrapper)
             for i in range(5):

--- a/deeplay/tests/test_layerlist.py
+++ b/deeplay/tests/test_layerlist.py
@@ -181,7 +181,7 @@ class TestLayerList(unittest.TestCase):
         nets = llist.net
         self.assertEqual(len(nets), 2)
         self.assertIsInstance(nets[0], nn.Linear)
-        self.assertIsInstance(nets[1], nn.Linear) 
+        self.assertIsInstance(nets[1], nn.Linear)
 
     def test_slice_does_not_mutate(self):
         llist = LayerList(
@@ -197,3 +197,32 @@ class TestLayerList(unittest.TestCase):
         for layer in llist[0:]:
             self.assertTrue(layer._has_built)
 
+    def test_layer_list_append_after_init(self):
+        llist = Wrapper1(3)
+        llist.layers.append(Layer(nn.Linear, 1, 1))
+        self.assertEqual(len(llist.layers), 4)
+        llist.build()
+        self.assertEqual(len(llist.layers), 4)
+
+    def test_layer_list_extend_after_init(self):
+        llist = Wrapper1(3)
+        llist.layers.extend([Layer(nn.Linear, 1, 1), Layer(nn.Linear, 1, 1)])
+        self.assertEqual(len(llist.layers), 5)
+        llist.build()
+        self.assertEqual(len(llist.layers), 5)
+
+    def test_layer_list_insert_after_init(self):
+        llist = Wrapper1(3)
+        llist.layers.insert(1, Layer(nn.Tanh))
+        self.assertEqual(len(llist.layers), 4)
+        self.assertIs(llist.layers[1].classtype, nn.Tanh)
+        llist.build()
+        self.assertEqual(len(llist.layers), 4)
+        self.assertIsInstance(llist.layers[1], nn.Tanh)
+
+    def test_layer_list_pop_after_init(self):
+        llist = Wrapper1(3)
+        llist.layers.pop()
+        self.assertEqual(len(llist.layers), 2)
+        llist.build()
+        self.assertEqual(len(llist.layers), 2)


### PR DESCRIPTION
adds decorator `@after_init` that 
1. Runs immediately on call
2. If called outside of `__init__`, also runs every time the object is initialized.

Example is `list.append`. `@after_init` ensures that any modifications of the list persists even if the object is re-initialized. Objects are re-initialized whenever they or a parent module is configured.

With the decorator, it's as easy as:
```py
@after_init
def append(self, item):
    super().append(item)
```