### PR TITLE
Fix config propagation in lists

### DIFF
--- a/deeplay/list.py
+++ b/deeplay/list.py
@@ -31,6 +31,9 @@ class LayerList(DeeplayModule, nn.ModuleList, Generic[T]):
     @after_init
     def append(self, module: DeeplayModule) -> "LayerList[T]":
         super().append(module)
+        if isinstance(module, DeeplayModule) and not module._has_built:
+            self._give_user_configuration(module, self._get_abs_string_index(-1))
+            module.__construct__()
         return self
 
     @after_init
@@ -40,21 +43,25 @@ class LayerList(DeeplayModule, nn.ModuleList, Generic[T]):
     @after_init
     def insert(self, index: int, module: DeeplayModule) -> "LayerList[T]":
         super().insert(index, module)
+        if isinstance(module, DeeplayModule) and not module._has_built:
+            self._give_user_configuration(module, self._get_abs_string_index(index))
+            module.__construct__()
         return self
 
     @after_init
     def extend(self, modules: List[DeeplayModule]) -> "LayerList[T]":
         super().extend(modules)
+        for idx, module in enumerate(modules):
+            if isinstance(module, DeeplayModule) and not module._has_built:
+                self._give_user_configuration(
+                    module, self._get_abs_string_index(idx + len(self) - len(modules))
+                )
+                module.__construct__()
         return self
 
     @after_init
     def remove(self, module: DeeplayModule) -> "LayerList[T]":
         super().remove(module)
-        return self
-
-    @after_init
-    def reverse(self) -> "LayerList[T]":
-        super().reverse()
         return self
 
     @overload

--- a/deeplay/module.py
+++ b/deeplay/module.py
@@ -448,12 +448,20 @@ class DeeplayModule(nn.Module, metaclass=ExtendedConstructorMeta):
         self.__construct__()
 
     def _give_user_configuration(self, receiver: "DeeplayModule", name):
-        if self._user_config is not None:
-            sub_config = receiver._collect_user_configuration()
-            for key, value in self._user_config.items():
-                if len(key) > 1 and key[0] == name:
-                    sub_config[key[1:]] = value
-            receiver._take_user_configuration(sub_config)
+        my_subconfigs = self._collect_user_configuration()
+        recevier_subconfigs = receiver._collect_user_configuration()
+
+        mysub = {
+            key[1:]: value
+            for key, value in my_subconfigs.items()
+            if len(key) > 1 and key[0] == name
+        }
+
+        subconfigs = {**mysub, **recevier_subconfigs}
+
+        # print("giving config with keys", subconfigs.keys(), "to", name)
+        # print("available keys", my_subconfigs.keys())
+        receiver._take_user_configuration(subconfigs)
 
     def _collect_user_configuration(self):
         config = self.get_user_configuration()
@@ -512,8 +520,8 @@ class DeeplayModule(nn.Module, metaclass=ExtendedConstructorMeta):
             self._modules.clear()
             self._is_constructing = True
             self.__init__(*self._args, **self.kwargs)
-            self._is_constructing = False
             self._run_hooks("after_init")
+            self._is_constructing = False
             self.__post_init__()
 
     @classmethod

--- a/deeplay/tests/test_layerlist.py
+++ b/deeplay/tests/test_layerlist.py
@@ -227,3 +227,56 @@ class TestLayerList(unittest.TestCase):
         self.assertEqual(len(llist.layers), 2)
         llist.build()
         self.assertEqual(len(llist.layers), 2)
+
+    def test_configuration_applies_in_wrapped(self):
+        class MLP(DeeplayModule):
+            def __init__(self, in_features, hidden_features, out_features):
+                self.in_features = in_features
+                self.hidden_features = hidden_features
+                self.out_features = out_features
+
+                self.blocks = LayerList()
+                self.blocks.append(
+                    LayerActivation(
+                        Layer(nn.Linear, in_features, hidden_features[0]),
+                        Layer(nn.ReLU),
+                    )
+                )
+
+                self.hidden_blocks = LayerList()
+                for i in range(len(hidden_features) - 1):
+                    self.hidden_blocks.append(
+                        LayerActivation(
+                            Layer(
+                                nn.Linear, hidden_features[i], hidden_features[i + 1]
+                            ),
+                            Layer(nn.ReLU),
+                        )
+                    )
+
+                self.blocks.extend(self.hidden_blocks)
+                self.blocks.insert(
+                    1,
+                    LayerActivation(
+                        Layer(nn.Linear, hidden_features[-1], out_features),
+                        Layer(nn.Sigmoid),
+                    ),
+                )
+
+        class TestClass(DeeplayModule):
+            def __init__(self, model=None):
+                super().__init__()
+
+                model = MLP(1, [1, 1], 1)
+                model.blocks[0].layer.configure(in_features=1, out_features=2)
+                model.blocks[1].layer.configure(in_features=1, out_features=2)
+                model.blocks[2].layer.configure(in_features=1, out_features=2)
+
+                self.model = model
+
+        testclass = TestClass()
+        testclass.build()
+        self.assertEqual(len(testclass.model.blocks), 3)
+        self.assertEqual(testclass.model.blocks[0].layer.out_features, 2)
+        self.assertEqual(testclass.model.blocks[1].layer.out_features, 2)
+        self.assertEqual(testclass.model.blocks[2].layer.out_features, 2)

--- a/deeplay/tests/test_module.py
+++ b/deeplay/tests/test_module.py
@@ -329,6 +329,23 @@ class TestLayer(unittest.TestCase):
 
         self.assertEqual(model.foo.num_features, 20)
 
+    def test_configure_in_init(self):
+        class TestClass(dl.DeeplayModule):
+            def __init__(self, model=None):
+                super().__init__()
+
+                model = dl.MultiLayerPerceptron(None, [64], 10)
+                model.output.normalization.configure(nn.BatchNorm1d)
+                self.model = model
+
+        testclass = TestClass()
+
+        self.assertEqual(testclass.model.output.normalization.classtype, nn.BatchNorm1d)
+
+        testclass.build()
+
+        self.assertIsInstance(testclass.model.output.normalization, nn.BatchNorm1d)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes an issue where configurations of models inside the `__init__` of a wrapper module would not apply if the submodule configured was an element of a `LayerList`