### PR TITLE
Add selection functionality to DeeplayModule

### DIFF
--- a/deeplay/list.py
+++ b/deeplay/list.py
@@ -123,7 +123,7 @@ class LayerList(DeeplayModule, nn.ModuleList, Generic[T]):
         ...
 
     def __getitem__(self, index: Union[int, slice]) -> "Union[T, LayerList[T]]":
-        return super().__getitem__(index)  # type: ignore
+        return nn.ModuleList.__getitem__(self, index)  # type: ignore
 
 
 class Sequential(LayerList, Generic[T]):

--- a/deeplay/module.py
+++ b/deeplay/module.py
@@ -487,6 +487,132 @@ class DeeplayModule(nn.Module, metaclass=ExtendedConstructorMeta):
             self._setattr_recording.add(name)
         super().__setattr__(name, value)
 
+    def _select_string(self, structure, selections, select, ellipsis=False):
+        selects = select.split(",")
+        selects = [select.strip() for select in selects]
+
+        selects_and_slices = []
+
+        for select in selects:
+            slicer = slice(None)
+            if "#" in select:
+                select, slice_str = select.split("#")
+                slice_str = slice_str.split(":")
+                slice_ints = [int(item) if item else None for item in slice_str]
+                if len(slice_str) == 1:
+                    if slice_ints[0] is None:
+                        slicer = slice(slice_ints[0], None)
+                    else:
+                        slicer = slice(slice_ints[0], slice_ints[0] + 1)
+                elif len(slice_str) == 2:
+                    slicer = slice(slice_ints[0], slice_ints[1])
+                else:
+                    slicer = slice(
+                        slice_ints[0],
+                        slice_ints[1],
+                        slice_ints[2],
+                    )
+            selects_and_slices.append((select, slicer))
+
+        new_selections = [[] for _ in range(len(selections))]
+        for select, slicer in selects_and_slices:
+            bar_selects = select.split("|")
+            bar_selects = [bar_select.strip() for bar_select in bar_selects]
+
+            for i, group in enumerate(selections):
+                group = selections[i]
+                new_group = []
+                for item in group:
+                    if ellipsis:
+                        for name in structure:
+                            if (
+                                len(name) > len(item)
+                                and name[-1] in bar_selects
+                                and name[: len(item)] == item
+                            ):
+                                new_group.append(name)
+                    else:
+                        for bar_select in bar_selects:
+                            new_select = item + (bar_select,)
+                            if new_select in structure:
+                                new_group.append(new_select)
+
+                new_group = new_group[slicer]
+                new_selections[i] += new_group
+
+        for i, group in enumerate(new_selections):
+            selections[i] = group
+
+    def getitem_with_selections(self, selector, selections=None):
+        if selections is None:
+            selections = [[()]]
+
+        names, _ = zip(*self.named_modules())
+
+        structure = {}
+        for name in names:
+            if name == "":
+                continue
+            key = tuple(name.split("."))
+            base = key[:-1]
+            name = key[-1]
+
+            if base not in structure:
+                structure[base] = []
+
+            structure[base].append(name)
+            structure[key] = []
+
+        if not isinstance(selector, tuple):
+            selector = (selector,)
+
+        selections = [[()]]
+        idx = 0
+        while idx < len(selector):
+            # flatten selections
+            new_selections = []
+            for group in selections:
+                new_selections += group
+            selections = [[item] for item in new_selections]
+
+            select = selector[idx]
+            if isinstance(select, int):
+                select = slice(select, select + 1)
+            if isinstance(select, str):
+                self._select_string(structure, selections, select)
+            if isinstance(select, type(...)):
+                if idx + 1 < len(selector):
+                    if not isinstance(selector[idx + 1], str):
+                        raise RuntimeError("Ellipsis must be followed by a string")
+                    idx += 1
+                    select = selector[idx]
+                    self._select_string(structure, selections, select, ellipsis=True)
+                else:
+                    for i, group in enumerate(selections):
+                        group = selections[i]
+                        new_group = []
+                        for item in group:
+                            for name in structure:
+                                if name[: len(item)] == item:
+                                    new_group.append(name)
+                        selections[i] = new_group
+            elif isinstance(select, slice):
+                for i, group in enumerate(selections):
+                    group = selections[i]
+                    new_group = []
+                    for item in group:
+                        children = structure[item]
+                        children = children[select]
+                        new_group += [item + (child,) for child in children]
+
+                    selections[i] = new_group
+
+            idx += 1
+        return Selection(self, selections)
+
+    def __getitem__(self, selector):
+        return self.getitem_with_selections(selector)
+
     def _build_arguments_from(self, *args, **kwargs):
         params = self.get_signature().parameters
 
@@ -541,3 +667,32 @@ class DeeplayModule(nn.Module, metaclass=ExtendedConstructorMeta):
         raise NotImplementedError(
             "forward method not implemented for {}".format(self.__class__.__name__)
         )
+
+
+class Selection(DeeplayModule):
+    def __init__(self, model, selections):
+        super().__init__()
+        self.model = model
+        self.selections = selections
+
+    def __getitem__(self, selector):
+        return self.model.getitem_with_selections(selector, self.selections.copy())
+
+    def __repr__(self):
+        for selection in self.selections:
+            for item in selection:
+                print(item)
+
+    def list_names(self):
+        names = []
+        for selection in self.selections:
+            for item in selection:
+                names.append(item)
+        return names
+
+    def configure(self, *args, **kwargs):
+        for selection in self.selections:
+            for item in selection:
+                for name, module in self.model.named_modules():
+                    if name.split(".") == item:
+                        module.configure(*args, **kwargs)

--- a/deeplay/module.py
+++ b/deeplay/module.py
@@ -610,7 +610,7 @@ class DeeplayModule(nn.Module, metaclass=ExtendedConstructorMeta):
             idx += 1
         return Selection(self, selections)
 
-    def __getitem__(self, selector):
+    def __getitem__(self, selector) -> "Selection":
         return self.getitem_with_selections(selector)
 
     def _build_arguments_from(self, *args, **kwargs):

--- a/deeplay/tests/test_selectors.py
+++ b/deeplay/tests/test_selectors.py
@@ -10,10 +10,10 @@ class TestModule(DeeplayModule):
 
         for i in range(4):
             self.encoder.append(
-                LayerActivation(Layer(nn.Conv2d, 3, 3, 1, 1), dl.Layer(nn.ReLU))
+                LayerActivation(Layer(nn.Conv2d, 3, 3, 1, 1), Layer(nn.ReLU))
             )
             self.decoder.append(
-                LayerActivation(Layer(nn.Conv2d, 3, 3, 1, 1), dl.Layer(nn.ReLU))
+                LayerActivation(Layer(nn.Conv2d, 3, 3, 1, 1), Layer(nn.ReLU))
             )
 
 

--- a/deeplay/tests/test_selectors.py
+++ b/deeplay/tests/test_selectors.py
@@ -31,4 +31,172 @@ class TestSelectors(unittest.TestCase):
 
     def test_selector_str_comma(self):
         selections = self.module["encoder,decoder"].list_names()
-        self.assertListEqual(selections, [("encoder", "decoder")])
+        self.assertListEqual(
+            selections,
+            [("encoder",), ("decoder",)],
+        )
+
+    def test_selector_str_slice(self):
+        selections = self.module["encoder", :2].list_names()
+        self.assertListEqual(
+            selections,
+            [
+                ("encoder", "0"),
+                ("encoder", "1"),
+            ],
+        )
+
+    def test_selector_str_slice_bar(self):
+        selections = self.module["encoder|decoder", :2].list_names()
+        self.assertListEqual(
+            selections,
+            [
+                ("encoder", "0"),
+                ("encoder", "1"),
+                ("decoder", "0"),
+                ("decoder", "1"),
+            ],
+        )
+
+    def test_selector_ellipsis_first(self):
+        selections = self.module[..., "layer"].list_names()
+        self.assertListEqual(
+            selections,
+            [
+                ("encoder", "0", "layer"),
+                ("encoder", "1", "layer"),
+                ("encoder", "2", "layer"),
+                ("encoder", "3", "layer"),
+                ("decoder", "0", "layer"),
+                ("decoder", "1", "layer"),
+                ("decoder", "2", "layer"),
+                ("decoder", "3", "layer"),
+            ],
+        )
+
+    def test_selector_ellipsis_last(self):
+        selections = self.module["encoder", 0, ...].list_names()
+        self.assertListEqual(
+            selections,
+            [
+                ("encoder", "0"),
+                ("encoder", "0", "layer"),
+                ("encoder", "0", "activation"),
+            ],
+        )
+
+    def test_selector_ellipsis_middle(self):
+        selections = self.module["encoder", ..., "layer"].list_names()
+        self.assertListEqual(
+            selections,
+            [
+                ("encoder", "0", "layer"),
+                ("encoder", "1", "layer"),
+                ("encoder", "2", "layer"),
+                ("encoder", "3", "layer"),
+            ],
+        )
+
+    def test_selector_ellipsis_middle_bar(self):
+        selections = self.module["encoder|decoder", ..., "layer"].list_names()
+        self.assertListEqual(
+            selections,
+            [
+                ("encoder", "0", "layer"),
+                ("encoder", "1", "layer"),
+                ("encoder", "2", "layer"),
+                ("encoder", "3", "layer"),
+                ("decoder", "0", "layer"),
+                ("decoder", "1", "layer"),
+                ("decoder", "2", "layer"),
+                ("decoder", "3", "layer"),
+            ],
+        )
+
+    def test_selector_hash(self):
+        selections = self.module["encoder", ..., "layer#0"].list_names()
+        self.assertListEqual(
+            selections,
+            [
+                ("encoder", "0", "layer"),
+            ],
+        )
+
+    def test_selector_hash_slice(self):
+        selections = self.module["encoder", ..., "layer#0:2"].list_names()
+        self.assertListEqual(
+            selections,
+            [
+                ("encoder", "0", "layer"),
+                ("encoder", "1", "layer"),
+            ],
+        )
+
+    def test_selector_has_slice_2(self):
+        selections = self.module["encoder", ..., "layer#::2"].list_names()
+        self.assertListEqual(
+            selections,
+            [
+                ("encoder", "0", "layer"),
+                ("encoder", "2", "layer"),
+            ],
+        )
+
+    def test_selector_has_slice_3(self):
+        selections = self.module["encoder", ..., "layer#1:3:2"].list_names()
+        self.assertListEqual(
+            selections,
+            [
+                ("encoder", "1", "layer"),
+            ],
+        )
+
+    def test_selector_bar_hash(self):
+        selections = self.module["encoder|decoder", ..., "layer#0"].list_names()
+        self.assertListEqual(
+            selections,
+            [
+                ("encoder", "0", "layer"),
+                ("decoder", "0", "layer"),
+            ],
+        )
+
+    def test_selector_bar_hash_2(self):
+        selections = self.module[..., "layer|activation#:2"].list_names()
+        self.assertListEqual(
+            selections,
+            [
+                ("encoder", "0", "layer"),
+                ("encoder", "0", "activation"),
+            ],
+        )
+
+    def test_selector_bar_hash_3(self):
+        selections = self.module[..., "layer#:2, activation#:2"].list_names()
+        self.assertListEqual(
+            selections,
+            [
+                ("encoder", "0", "layer"),
+                ("encoder", "1", "layer"),
+                ("encoder", "0", "activation"),
+                ("encoder", "1", "activation"),
+            ],
+        )
+
+    def test_selector_bar_hash_4(self):
+        selections = self.module[
+            "encoder|decoder", ..., "layer#:2, activation#:2"
+        ].list_names()
+        self.assertListEqual(
+            selections,
+            [
+                ("encoder", "0", "layer"),
+                ("encoder", "1", "layer"),
+                ("encoder", "0", "activation"),
+                ("encoder", "1", "activation"),
+                ("decoder", "0", "layer"),
+                ("decoder", "1", "layer"),
+                ("decoder", "0", "activation"),
+                ("decoder", "1", "activation"),
+            ],
+        )

--- a/deeplay/tests/test_selectors.py
+++ b/deeplay/tests/test_selectors.py
@@ -1,18 +1,19 @@
-import deeplay as dl
+from .. import DeeplayModule, LayerList, LayerActivation, Layer
 import unittest
+import torch.nn as nn
 
 
-class TestModule(dl.DeeplayModule):
+class TestModule(DeeplayModule):
     def __init__(self):
-        self.encoder = dl.LayerList()
-        self.decoder = dl.LayerList()
+        self.encoder = LayerList()
+        self.decoder = LayerList()
 
         for i in range(4):
             self.encoder.append(
-                dl.LayerActivation(dl.Layer(nn.Conv2d, 3, 3, 1, 1), dl.Layer(nn.ReLU))
+                LayerActivation(Layer(nn.Conv2d, 3, 3, 1, 1), dl.Layer(nn.ReLU))
             )
             self.decoder.append(
-                dl.LayerActivation(dl.Layer(nn.Conv2d, 3, 3, 1, 1), dl.Layer(nn.ReLU))
+                LayerActivation(Layer(nn.Conv2d, 3, 3, 1, 1), dl.Layer(nn.ReLU))
             )
 
 
@@ -21,13 +22,13 @@ class TestSelectors(unittest.TestCase):
         self.module = TestModule()
 
     def test_selector_str(self):
-        selections = self.module["encoder"]
+        selections = self.module["encoder"].list_names()
         self.assertListEqual(selections, [("encoder",)])
 
     def test_selector_str_bar(self):
-        selections = self.module["encoder|decoder"]
+        selections = self.module["encoder|decoder"].list_names()
         self.assertListEqual(selections, [("encoder",), ("decoder",)])
 
     def test_selector_str_comma(self):
-        selections = self.module["encoder,decoder"]
+        selections = self.module["encoder,decoder"].list_names()
         self.assertListEqual(selections, [("encoder", "decoder")])

--- a/deeplay/tests/test_selectors.py
+++ b/deeplay/tests/test_selectors.py
@@ -1,0 +1,33 @@
+import deeplay as dl
+import unittest
+
+
+class TestModule(dl.DeeplayModule):
+    def __init__(self):
+        self.encoder = dl.LayerList()
+        self.decoder = dl.LayerList()
+
+        for i in range(4):
+            self.encoder.append(
+                dl.LayerActivation(dl.Layer(nn.Conv2d, 3, 3, 1, 1), dl.Layer(nn.ReLU))
+            )
+            self.decoder.append(
+                dl.LayerActivation(dl.Layer(nn.Conv2d, 3, 3, 1, 1), dl.Layer(nn.ReLU))
+            )
+
+
+class TestSelectors(unittest.TestCase):
+    def setUp(self) -> None:
+        self.module = TestModule()
+
+    def test_selector_str(self):
+        selections = self.module["encoder"]
+        self.assertListEqual(selections, [("encoder",)])
+
+    def test_selector_str_bar(self):
+        selections = self.module["encoder|decoder"]
+        self.assertListEqual(selections, [("encoder",), ("decoder",)])
+
+    def test_selector_str_comma(self):
+        selections = self.module["encoder,decoder"]
+        self.assertListEqual(selections, [("encoder", "decoder")])


### PR DESCRIPTION
# Enhanced Submodule Selection and Configuration in PyTorch Modules

## Description:
I'm are excited to introduce a new feature in our Python library that significantly enhances the way users interact with PyTorch modules. This latest pull request (PR) adds a powerful syntax using `__getitem__` for selecting submodules within a PyTorch module, enabling a more intuitive and flexible approach to configuring neural networks.

## Key Feature:

Selective Submodule Extraction: Utilize the `__getitem__` method to extract specific submodules from a larger PyTorch module. This feature allows users to pinpoint and manipulate subsets of their neural network models with ease.



## Examples of Usage:
- Basic Selection:
   - `cnn["blocks"]`: Directly access the 'blocks' submodule in a convolutional neural network (CNN).
- Advanced Pattern Matching:
    - `cnn[..., "layer"]`: Select all submodules named 'layer' at any depth within the network.
    - `cnn[..., "pool#:2"]`: Choose the first two submodules named 'pool'.
    - `cnn[..., "layer|activation"]`: Access all modules named either 'layer' or 'activation'.
    - `cnn[..., "layer|activation#:2"]`: Select the first two modules named either 'layer' or 'activation'.
    - `cnn[..., "layer#:2, activation#:2]`: Pick the first two 'layer' modules and the first two 'activation' modules.
- Indexed Submodule Selection:
    - `cnn["blocks", :2, "activation"]`: Select the activation functions of the first two blocks in the 'blocks' submodule.
    - `cnn["blocks", 0, ...]`: Access all submodules of the first block in 'blocks'.
    - `cnn["blocks", 0, :]`: Choose all submodules one level deep within the first block.
- Complex Configurations:
    - `encdec["encoder|decoder", ..., "layer#:2"]`: In an encoder-decoder model, select the first two layers of both the encoder and decoder separately.
    - `encdec["encoder|decoder", "blocks", ..., "layer#:2"]`: Similar selection but focused within the 'blocks' submodule of both encoder and decoder.
    - `encdec["encoder|decoder", "blocks", :, "layer#:2"]`: Select the first two layers of each block within both encoder and decoder.

### Configuring Selected Submodules:
Once a selection is made, users can conveniently configure the selected submodules. For example:

- `cnn[..., "layer#:4"].configure(kernel_size=5)`: This command configures the first four 'layer' submodules, setting their kernel_size to 5.

## Open design question

We could instead have the syntax be 
```py
cnn.select[..., "layer#:4"]
```
similar to pandas `DataFrame.at[:, "x"]`

The reason would be to not interfere with the `__getitem__` of `LayerList` and potentially `LayerDict`. I don't expect it to be a problem. I personally prefer `__getitem__` but I'm fine with `select`.

## Final words

This new feature promises to streamline the process of neural network configuration, making it more intuitive and efficient. I welcome feedback and contributions to further improve this functionality.