### PR TITLE
Transformer Encoder

### DIFF
--- a/deeplay/components/__init__.py
+++ b/deeplay/components/__init__.py
@@ -4,3 +4,4 @@ from .dcgan import *
 from .gnn import *
 from .cyclegan import *
 from .dict import *
+from .transformer import *

--- a/deeplay/components/mlp.py
+++ b/deeplay/components/mlp.py
@@ -93,12 +93,14 @@ class MultiLayerPerceptron(DeeplayModule):
         hidden_features: Sequence[Optional[int]],
         out_features: int,
         out_activation: Union[Type[nn.Module], nn.Module, None] = None,
+        flatten_input: bool = True,
     ):
         super().__init__()
 
         self.in_features = in_features
         self.hidden_features = hidden_features
         self.out_features = out_features
+        self.flatten_input = flatten_input
 
         if out_features <= 0:
             raise ValueError(
@@ -146,7 +148,7 @@ class MultiLayerPerceptron(DeeplayModule):
         )
 
     def forward(self, x):
-        x = nn.Flatten()(x)
+        x = nn.Flatten()(x) if self.flatten_input else x
         for block in self.blocks:
             x = block(x)
         return x

--- a/deeplay/components/transformer/__init__.py
+++ b/deeplay/components/transformer/__init__.py
@@ -1,0 +1,3 @@
+from .satt import MultiheadSelfAttention
+from .ldsn import LayerSkipNormalization
+from .enc import Add, TransformerEncoderLayer

--- a/deeplay/components/transformer/enc.py
+++ b/deeplay/components/transformer/enc.py
@@ -57,6 +57,10 @@ class TransformerEncoderLayer(DeeplayModule):
     --------
     >>> tel = TransformerEncoderLayer(4, [4, 16], 4, 2)
     >>> tel.build()
+    >>> seq_len, batch_size,features = 2, 10, 4
+    >>> input_seq = torch.randn(seq_len, batch_size, features)
+    >>> tel(input_seq).shape
+    torch.Size([2, 10, 4])
 
 
     Return Values

--- a/deeplay/components/transformer/enc.py
+++ b/deeplay/components/transformer/enc.py
@@ -14,15 +14,56 @@ from functools import reduce
 
 
 class Add(DeeplayModule):
+    """Addition module.
+
+    Adds input tensors element-wise.
+
+    Examples
+    --------
+    >>> add = Add()
+    >>> add(torch.randn(4, 4), torch.randn(4, 4))
+    """
+
     def forward(self, *x):
-        """
-        Add the input tensors element-wise.
-        """
         x = itertools.chain(*x) if isinstance(x[0], tuple) else x
         return reduce(lambda a, b: torch.add(a, b), x)
 
 
 class TransformerEncoderLayer(DeeplayModule):
+    """Transformer encoder module.
+
+    Configurables
+    -------------
+    - in_features (int): Number of input features. If None, the input shape is inferred in the first forward pass. (Default: None)
+    - hidden_features (list[int]): Number of hidden units in each layer.
+    - out_features (int): Number of output features.
+    - num_heads (int): Number of attention heads.
+
+    Shorthands
+    ----------
+    - `input`: Equivalent to `.blocks[0]`.
+    - `hidden`: Equivalent to `.blocks[:-1]`.
+    - `output`: Equivalent to `.blocks[-1]`.
+    - `multihead`: Equivalent to `.blocks.multihead`.
+    - `feed_forward`: Equivalent to `.blocks.feed_forward`.
+
+    Evaluation
+    ----------
+    >>> for block in tel.blocks:
+    >>>    x = block(x)
+    >>> return x
+
+    Examples
+    --------
+    >>> tel = TransformerEncoderLayer(4, [4, 16], 4, 2)
+    >>> tel.build()
+
+
+    Return Values
+    -------------
+    The forward method returns the processed tensor.
+    """
+
     input_features: int
     hidden_features: Sequence[Optional[int]]
     out_features: int

--- a/deeplay/components/transformer/enc.py
+++ b/deeplay/components/transformer/enc.py
@@ -1,0 +1,136 @@
+from typing import List, Optional, Literal, Any, Sequence, Type, overload, Union
+
+from .. import DeeplayModule, Layer, LayerList
+from . import LayerSkipNormalization, MultiheadSelfAttention
+
+from deeplay.blocks.sequential import SequentialBlock
+from deeplay import Sequential
+
+import torch
+import torch.nn as nn
+
+import itertools
+from functools import reduce
+
+
+class Add(DeeplayModule):
+    def forward(self, *x):
+        """
+        Add the input tensors element-wise.
+        """
+        x = itertools.chain(*x) if isinstance(x[0], tuple) else x
+        return reduce(lambda a, b: torch.add(a, b), x)
+
+
+class TransformerEncoderLayer(DeeplayModule):
+    input_features: int
+    hidden_features: Sequence[Optional[int]]
+    out_features: int
+    num_heads: int
+    blocks: LayerList[Sequential]
+
+    @property
+    def input(self):
+        """Return the input layer of the network. Equivalent to `.blocks[0]`."""
+        return self.blocks[0]
+
+    @property
+    def hidden(self):
+        """Return the hidden layers of the network. Equivalent to `.blocks[:-1]`"""
+        return self.blocks[:-1]
+
+    @property
+    def output(self):
+        """Return the last layer of the network. Equivalent to `.blocks[-1]`."""
+        return self.blocks[-1]
+
+    @property
+    def multihead(self):
+        """Return the multihead attention layer of the network. Equivalent to
+        `.blocks.multihead.layer`."""
+        return self.blocks.multihead
+
+    @property
+    def feed_forward(self):
+        """Return the feed forward layer of the network. Equivalent to
+        `.blocks.feed_forward`."""
+        return self.blocks.feed_forward
+
+    def __init__(
+        self,
+        in_features: Optional[int],
+        hidden_features: Sequence[Optional[int]],
+        out_features: int,
+        num_heads: int,
+    ):
+        super().__init__()
+
+        self.in_features = in_features
+        self.hidden_features = hidden_features
+        self.out_features = out_features
+        self.num_heads = num_heads
+
+        if out_features <= 0:
+            raise ValueError(
+                f"Number of output features must be positive, got {out_features}"
+            )
+
+        if in_features is not None and in_features <= 0:
+            raise ValueError(f"in_channels must be positive, got {in_features}")
+
+        if any(h <= 0 for h in hidden_features):
+            raise ValueError(
+                f"all hidden_channels must be positive, got {hidden_features}"
+            )
+
+        self.blocks = LayerList()
+
+        for i, (f_in, f_out) in enumerate(
+            zip([in_features, *hidden_features], [*hidden_features, out_features])
+        ):
+            self.blocks.append(
+                SequentialBlock(
+                    # First sub-block is multihead self-attention followed by
+                    # skip connection and normalization.
+                    multihead=LayerSkipNormalization(
+                        layer=MultiheadSelfAttention(
+                            f_out,
+                            num_heads,
+                            projection=Layer(nn.LazyLinear, f_out)
+                            if f_in != f_out
+                            else Layer(nn.Identity),
+                        ),
+                        skip=Add(),
+                        normalization=Layer(nn.LayerNorm, f_out),
+                    ),
+                    # Second sub-block is feed forward followed by skip connection
+                    # and normalization
+                    feed_forward=LayerSkipNormalization(
+                        layer=Sequential(
+                            Layer(nn.Linear, f_out, f_out),
+                            Layer(nn.ReLU),
+                            Layer(nn.Linear, f_out, f_out),
+                        ),
+                        skip=Add(),
+                        normalization=Layer(nn.LayerNorm, f_out),
+                    ),
+                )
+            )
+
+    def forward(self, x):
+        for block in self.blocks:
+            x = block(x)
+        return x
+
+    @overload
+    def configure(
+        self,
+        /,
+        in_features: Optional[int] = None,
+        hidden_features: Optional[List[int]] = None,
+        out_features: Optional[int] = None,
+        num_heads: Optional[int] = None,
+    ) -> None:
+        ...
+
+    configure = DeeplayModule.configure

--- a/deeplay/components/transformer/enc.py
+++ b/deeplay/components/transformer/enc.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Literal, Any, Sequence, Type, overload, Union
 
-from .. import DeeplayModule, Layer, LayerList
+from .. import DeeplayModule, Layer, LayerList, MultiLayerPerceptron
 from . import LayerSkipNormalization, MultiheadSelfAttention
 
 from deeplay.blocks.sequential import SequentialBlock
@@ -147,10 +147,8 @@ class TransformerEncoderLayer(DeeplayModule):
                     # Second sub-block is feed forward followed by skip connection
                     # and normalization
                     feed_forward=LayerSkipNormalization(
-                        layer=Sequential(
-                            Layer(nn.Linear, f_out, f_out),
-                            Layer(nn.ReLU),
-                            Layer(nn.Linear, f_out, f_out),
+                        layer=MultiLayerPerceptron(
+                            f_out, [f_out], f_out, flatten_input=False
                         ),
                         skip=Add(),
                         normalization=Layer(nn.LayerNorm, f_out),

--- a/deeplay/components/transformer/ldsn.py
+++ b/deeplay/components/transformer/ldsn.py
@@ -1,0 +1,54 @@
+from typing import List, overload, Optional, Literal, Any, Union, Type, Sequence
+
+import torch.nn as nn
+
+from deeplay import DeeplayModule
+
+
+class LayerSkipNormalization(DeeplayModule):
+    layer: nn.Module
+    skip: nn.Module
+    normalization: nn.Module
+
+    def __init__(
+        self,
+        layer: nn.Module,
+        skip: nn.Module,
+        normalization: nn.Module,
+    ):
+        super().__init__()
+
+        self.layer = layer
+        self.skip = skip
+        self.normalization = normalization
+
+    def forward(self, x):
+        x = self.layer(x)
+        x = self.skip(x)
+        x = self.normalization(x)
+        return x
+
+    @overload
+    def configure(
+        self,
+        /,
+        layer: Union[Type[nn.Module], nn.Module],
+        skip: Union[Type[nn.Module], nn.Module],
+        normalization: Union[Type[nn.Module], nn.Module],
+    ) -> None:
+        ...
+
+    @overload
+    def configure(
+        self,
+        name: Literal["blocks"],
+        index: Union[int, slice, List[Union[int, slice]], None] = None,
+        order: Optional[Sequence[str]] = None,
+        layer: Optional[Type[nn.Module]] = None,
+        skip: Optional[Type[nn.Module]] = None,
+        normalization: Optional[Type[nn.Module]] = None,
+        **kwargs: Any,
+    ) -> None:
+        ...
+
+    configure = DeeplayModule.configure

--- a/deeplay/components/transformer/satt.py
+++ b/deeplay/components/transformer/satt.py
@@ -1,0 +1,61 @@
+from deeplay import DeeplayModule, Layer
+
+import torch
+import torch.nn as nn
+
+
+class MultiheadSelfAttention(DeeplayModule):
+    features: int
+    num_heads: int
+    projection: DeeplayModule
+    return_attn: bool
+
+    def __init__(
+        self,
+        features: int,
+        num_heads: int,
+        projection: DeeplayModule = Layer(nn.Identity),
+        return_attn: bool = False,
+    ):
+        super().__init__()
+        self.features = features
+        self.num_heads = num_heads
+        self.projection = projection
+
+        self.return_attn = return_attn
+
+        if features <= 0:
+            raise ValueError(f"Number of features must be positive, got {features}")
+
+        self.attention = Layer(nn.MultiheadAttention, features, num_heads)
+
+    def forward(self, x, batch_index=None):
+        """Apply multihead self-attention to the input tensor.
+        Returns (y, attn, x) if return_attn is True, otherwise returns (y, x).
+        y is the output of the multihead self-attention layer, attn is the
+        attention matrix, and x is the input to the multihead self-attention.
+        If projection is nn.Identity, then x is the same as the input to the
+        multihead self-attention. Otherwise, x is the output of the projection
+        layer.
+        """
+        attn_mask = None
+        if x.ndim == 2:
+            if batch_index is None:
+                raise ValueError("batch_index must be provided for 2D tensor. Got None")
+            attn_mask = self._fetch_attn_mask(batch_index)
+
+        x = self.projection(x)
+        y, attn = self.attention(x, x, x, attn_mask=attn_mask)
+
+        if self.return_attn:
+            return y, attn, x
+        else:
+            return y, x
+
+    def _fetch_attn_mask(self, batch_index):
+        """Fetch attention mask for 2D tensor. The mask is a square matrix with
+        True values indicating that the corresponding element is not allowed
+        to attend. This is used to deal with unbached sequences of different
+        lengths.
+        """
+        return ~torch.eq(batch_index.unsqueeze(1), batch_index.unsqueeze(0))

--- a/deeplay/components/transformer/satt.py
+++ b/deeplay/components/transformer/satt.py
@@ -7,14 +7,14 @@ import torch.nn as nn
 class MultiheadSelfAttention(DeeplayModule):
     features: int
     num_heads: int
-    projection: DeeplayModule
+    projection: nn.Module
     return_attn: bool
 
     def __init__(
         self,
         features: int,
         num_heads: int,
-        projection: DeeplayModule = Layer(nn.Identity),
+        projection: nn.Module = nn.Identity(),
         return_attn: bool = False,
     ):
         super().__init__()

--- a/deeplay/tests/test_transformers.py
+++ b/deeplay/tests/test_transformers.py
@@ -40,6 +40,16 @@ class TestComponentTransformerEncoder(unittest.TestCase):
         self.assertEqual(tel.blocks[0].feed_forward.layer[0].in_features, 4)
         self.assertEqual(tel.blocks[0].feed_forward.layer[-1].out_features, 4)
 
+    def test_variable_hidden_layers(self):
+        tel = TransformerEncoderLayer(4, [4, 8, 16], 4, 2)
+        tel.build()
+        self.assertEqual(len(tel.blocks), 4)
+
+        self.assertEqual(tel.blocks[0].multihead.layer.attention.embed_dim, 4)
+        self.assertEqual(tel.blocks[1].multihead.layer.attention.embed_dim, 8)
+        self.assertEqual(tel.blocks[2].multihead.layer.attention.embed_dim, 16)
+        self.assertEqual(tel.blocks[3].multihead.layer.attention.embed_dim, 4)
+
     def test_tel_multihead_subcomponents(self):
         tel = TransformerEncoderLayer(4, [4], 4, 2)
         tel.multihead[0].layer.configure("return_attn", True)

--- a/deeplay/tests/test_transformers.py
+++ b/deeplay/tests/test_transformers.py
@@ -1,0 +1,72 @@
+import unittest
+import torch
+import torch.nn as nn
+from deeplay import TransformerEncoderLayer, Layer
+
+
+class TestComponentTransformerEncoder(unittest.TestCase):
+    ...
+
+    def test_tel_defaults(self):
+        tel = TransformerEncoderLayer(4, [4], 4, 2)
+        tel.build()
+        self.assertEqual(len(tel.blocks), 2)
+
+        self.assertEqual(tel.blocks[0].multihead.layer.attention.embed_dim, 4)
+        self.assertEqual(tel.blocks[0].multihead.layer.attention.num_heads, 2)
+
+        self.assertEqual(tel.blocks[0].feed_forward.layer[0].in_features, 4)
+        self.assertEqual(tel.blocks[0].feed_forward.layer[-1].out_features, 4)
+
+        # test on a batch of 2
+        x = torch.randn(2, 10, 4)
+        y = tel(x)
+        self.assertEqual(y.shape, (2, 10, 4))
+
+    def test_tel_change_depth(self):
+        tel = TransformerEncoderLayer(4, [4], 4, 2)
+        tel.configure(hidden_features=[4, 4])
+        tel.build()
+        self.assertEqual(len(tel.blocks), 3)
+
+    def test_no_hidden_layers(self):
+        tel = TransformerEncoderLayer(4, [], 4, 2)
+        tel.build()
+        self.assertEqual(len(tel.blocks), 1)
+
+        self.assertEqual(tel.blocks[0].multihead.layer.attention.embed_dim, 4)
+        self.assertEqual(tel.blocks[0].multihead.layer.attention.num_heads, 2)
+
+        self.assertEqual(tel.blocks[0].feed_forward.layer[0].in_features, 4)
+        self.assertEqual(tel.blocks[0].feed_forward.layer[-1].out_features, 4)
+
+    def test_tel_multihead_subcomponents(self):
+        tel = TransformerEncoderLayer(4, [4], 4, 2)
+        tel.multihead[0].layer.configure("return_attn", True)
+        tel.build()
+
+        multihead = tel.multihead[0].layer
+
+        # We now evaluate an input tensor of shape (10, 4) with batch index
+        # (0, 0, 0, 0, 0, 0, 0, 0, 0, 1). The last element of the batch index
+        # indicates that the last element of the input tensor is not allowed
+        # to attend to any other element.
+        x = torch.randn(10, 4)
+        batch_index = torch.zeros(10, dtype=torch.long)
+        batch_index[-1] = 1
+
+        y, attn, x = multihead(x, batch_index=batch_index)
+        self.assertEqual(y.shape, (10, 4))
+        self.assertEqual(attn.shape, (10, 10))
+        self.assertEqual(x.shape, (10, 4))
+
+        self.assertEqual(attn.sum(dim=-1).sum(), 10)
+        self.assertEqual(attn[-1, -1], 1.0)
+
+        skip = tel.multihead[0].skip
+        y1 = skip(y, x)  # as given by a dict mapping
+        y2 = skip((y, x))
+
+        self.assertEqual(y1.shape, (10, 4))
+        self.assertEqual(y2.shape, (10, 4))
+        self.assertEqual((y1 - y2).sum(), 0.0)

--- a/deeplay/tests/test_transformers.py
+++ b/deeplay/tests/test_transformers.py
@@ -12,16 +12,17 @@ class TestComponentTransformerEncoder(unittest.TestCase):
         tel.build()
         self.assertEqual(len(tel.blocks), 2)
 
-        self.assertEqual(tel.blocks[0].multihead.layer.attention.embed_dim, 4)
-        self.assertEqual(tel.blocks[0].multihead.layer.attention.num_heads, 2)
+        for i in range(2):
+            self.assertEqual(tel.blocks[i].multihead.layer.attention.embed_dim, 4)
+            self.assertEqual(tel.blocks[i].multihead.layer.attention.num_heads, 2)
 
-        self.assertEqual(tel.blocks[0].feed_forward.layer[0].in_features, 4)
-        self.assertEqual(tel.blocks[0].feed_forward.layer[-1].out_features, 4)
+            self.assertEqual(tel.blocks[i].feed_forward.layer.layer[0].in_features, 4)
+            self.assertEqual(tel.blocks[i].feed_forward.layer.layer[-1].out_features, 4)
 
         # test on a batch of 2
-        x = torch.randn(2, 10, 4)
+        x = torch.randn(10, 2, 4)
         y = tel(x)
-        self.assertEqual(y.shape, (2, 10, 4))
+        self.assertEqual(y.shape, (10, 2, 4))
 
     def test_tel_change_depth(self):
         tel = TransformerEncoderLayer(4, [4], 4, 2)
@@ -37,8 +38,8 @@ class TestComponentTransformerEncoder(unittest.TestCase):
         self.assertEqual(tel.blocks[0].multihead.layer.attention.embed_dim, 4)
         self.assertEqual(tel.blocks[0].multihead.layer.attention.num_heads, 2)
 
-        self.assertEqual(tel.blocks[0].feed_forward.layer[0].in_features, 4)
-        self.assertEqual(tel.blocks[0].feed_forward.layer[-1].out_features, 4)
+        self.assertEqual(tel.blocks[0].feed_forward.layer.layer[0].in_features, 4)
+        self.assertEqual(tel.blocks[0].feed_forward.layer.layer[-1].out_features, 4)
 
     def test_variable_hidden_layers(self):
         tel = TransformerEncoderLayer(4, [4, 8, 16], 4, 2)


### PR DESCRIPTION
This pull request introduces the `TransformerEncoderLayer` component as outlined in "[Attention Is All You Need](https://arxiv.org/abs/1706.03762)". Additionally, the pull request brings in a new processing block called `LayerSkipNormalization` and the DeeplayModule `MultiheadSelfAttention`.   

The `MultiheadSelfAttention` module is designed to handle both batched and unbatched sequences. When processing unbatched inputs, the module incorporates a mechanism where `batch_indices` are accepted. These indices help condition the attention weights of each item, ensuring that they exclusively attend to other items within the same batch.