### PR TITLE
Add logging functionality to DeeplayModule and Selection classes

### DIFF
--- a/deeplay/external/external.py
+++ b/deeplay/external/external.py
@@ -101,8 +101,10 @@ class External(DeeplayModule):
                 kwargs.pop(key)
 
         obj = self.classtype(*args, **kwargs)
-        self._execute_mapping_if_valid(obj)
 
+        if not isinstance(obj, DeeplayModule):
+            obj._root_module = self._root_module
+        self._execute_mapping_if_valid(obj)
         self._run_hooks("after_build", obj)
         return obj
 
@@ -149,12 +151,10 @@ class External(DeeplayModule):
         return kwargs
 
     @overload
-    def configure(self, classtype, **kwargs) -> None:
-        ...
+    def configure(self, classtype, **kwargs) -> None: ...
 
     @overload
-    def configure(self, **kwargs: Any) -> None:
-        ...
+    def configure(self, **kwargs: Any) -> None: ...
 
     def configure(self, classtype: Optional[type] = None, **kwargs):
         if classtype is not None:

--- a/deeplay/tests/test_log_input_output.py
+++ b/deeplay/tests/test_log_input_output.py
@@ -1,0 +1,129 @@
+import unittest
+import deeplay as dl
+import torch
+import torch.nn as nn
+
+
+class LogModule(dl.DeeplayModule):
+    def __init__(self):
+        self.cnn = dl.MultiLayerPerceptron(1, [1, 1], 1)
+        self.layer = dl.Layer(nn.Linear, 1, 1)
+
+        self.cnn_in = None
+        self.cnn_out = None
+        self.layer_in = None
+        self.layer_out = None
+
+    def forward(self, x):
+        self.cnn_in = x
+        x = self.cnn(x)
+        self.cnn_out = x
+        self.layer_in = x
+        x = self.layer(x)
+        self.layer_out = x
+        return x
+
+
+class TestLogInputOutput(unittest.TestCase):
+    def test_log_input_output(self):
+        model = LogModule()
+        model.cnn.log_input("cnn_in")
+        model.cnn.log_output("cnn_out")
+        model.layer.log_input("layer_in")
+        model.layer.log_output("layer_out")
+
+        model.build()
+
+        model.forward(torch.rand(1, 1))
+
+        self.assertEqual(len(model.logs), 4)
+        self.assertEqual(model.cnn_in[0, 0], model.logs["cnn_in"][0][0, 0])
+        self.assertEqual(model.cnn_out[0, 0], model.logs["cnn_out"][0, 0])
+        self.assertEqual(model.layer_in[0, 0], model.logs["layer_in"][0][0, 0])
+        self.assertEqual(model.layer_out[0, 0], model.logs["layer_out"][0, 0])
+
+        model.forward(torch.rand(1, 1))
+
+        self.assertEqual(len(model.logs), 4)
+        self.assertEqual(model.cnn_in[0, 0], model.logs["cnn_in"][0][0, 0])
+        self.assertEqual(model.cnn_out[0, 0], model.logs["cnn_out"][0, 0])
+        self.assertEqual(model.layer_in[0, 0], model.logs["layer_in"][0][0, 0])
+        self.assertEqual(model.layer_out[0, 0], model.logs["layer_out"][0, 0])
+
+    def test_log_input_output_create(self):
+        model = LogModule()
+
+        model.cnn.log_input("cnn_in")
+        model.cnn.log_output("cnn_out")
+        model.layer.log_input("layer_in")
+        model.layer.log_output("layer_out")
+
+        model = model.create()
+
+        model.forward(torch.rand(1, 1))
+
+        self.assertEqual(len(model.logs), 4)
+        self.assertEqual(model.cnn_in[0, 0], model.logs["cnn_in"][0][0, 0])
+        self.assertEqual(model.cnn_out[0, 0], model.logs["cnn_out"][0, 0])
+        self.assertEqual(model.layer_in[0, 0], model.logs["layer_in"][0][0, 0])
+        self.assertEqual(model.layer_out[0, 0], model.logs["layer_out"][0, 0])
+
+        model.forward(torch.rand(1, 1))
+
+        self.assertEqual(len(model.logs), 4)
+        self.assertEqual(model.cnn_in[0, 0], model.logs["cnn_in"][0][0, 0])
+        self.assertEqual(model.cnn_out[0, 0], model.logs["cnn_out"][0, 0])
+        self.assertEqual(model.layer_in[0, 0], model.logs["layer_in"][0][0, 0])
+        self.assertEqual(model.layer_out[0, 0], model.logs["layer_out"][0, 0])
+
+    def test_log_input_output_selection(self):
+        model = LogModule()
+
+        model["cnn"].log_input("cnn_in")
+        model["cnn"].log_output("cnn_out")
+        model["layer"].log_input("layer_in")
+        model["layer"].log_output("layer_out")
+
+        model.build()
+
+        model.forward(torch.rand(1, 1))
+
+        self.assertEqual(len(model.logs), 4)
+        self.assertEqual(model.cnn_in[0, 0], model.logs["cnn_in"][0][0, 0])
+        self.assertEqual(model.cnn_out[0, 0], model.logs["cnn_out"][0, 0])
+        self.assertEqual(model.layer_in[0, 0], model.logs["layer_in"][0][0, 0])
+        self.assertEqual(model.layer_out[0, 0], model.logs["layer_out"][0, 0])
+
+        model.forward(torch.rand(1, 1))
+
+        self.assertEqual(len(model.logs), 4)
+        self.assertEqual(model.cnn_in[0, 0], model.logs["cnn_in"][0][0, 0])
+        self.assertEqual(model.cnn_out[0, 0], model.logs["cnn_out"][0, 0])
+        self.assertEqual(model.layer_in[0, 0], model.logs["layer_in"][0][0, 0])
+        self.assertEqual(model.layer_out[0, 0], model.logs["layer_out"][0, 0])
+
+    def test_log_input_output_selection_create(self):
+        model = LogModule()
+
+        model["cnn"].log_input("cnn_in")
+        model["cnn"].log_output("cnn_out")
+        model["layer"].log_input("layer_in")
+        model["layer"].log_output("layer_out")
+
+        model = model.create()
+
+        model.forward(torch.rand(1, 1))
+
+        self.assertEqual(len(model.logs), 4)
+        self.assertEqual(model.cnn_in[0, 0], model.logs["cnn_in"][0][0, 0])
+        self.assertEqual(model.cnn_out[0, 0], model.logs["cnn_out"][0, 0])
+        self.assertEqual(model.layer_in[0, 0], model.logs["layer_in"][0][0, 0])
+        self.assertEqual(model.layer_out[0, 0], model.logs["layer_out"][0, 0])
+
+        model.forward(torch.rand(1, 1))
+
+        self.assertEqual(len(model.logs), 4)
+        self.assertEqual(model.cnn_in[0, 0], model.logs["cnn_in"][0][0, 0])
+        self.assertEqual(model.cnn_out[0, 0], model.logs["cnn_out"][0, 0])
+        self.assertEqual(model.layer_in[0, 0], model.logs["layer_in"][0][0, 0])
+        self.assertEqual(model.layer_out[0, 0], model.logs["layer_out"][0, 0])


### PR DESCRIPTION
Introduces ability to log intermediate inputs and outputs:

```py
model = dl.MultiLayerPerceptron(28*28, [32, 16], 10)
model.output.log_input("embedding")

model.build()

logits = model(x)
embeddings = model.logs["embedding"] 
```

Main use is variational AEs, active learning, and visualization