### PR TITLE
Add LayerDropoutSkipNormalization to Transformer models

### DIFF
--- a/deeplay/components/transformer/__init__.py
+++ b/deeplay/components/transformer/__init__.py
@@ -1,3 +1,3 @@
 from .satt import MultiheadSelfAttention
-from .ldsn import LayerSkipNormalization
+from .ldsn import LayerDropoutSkipNormalization
 from .enc import Add, TransformerEncoderLayer

--- a/deeplay/components/transformer/enc.py
+++ b/deeplay/components/transformer/enc.py
@@ -1,7 +1,7 @@
 from typing import List, Optional, Literal, Any, Sequence, Type, overload, Union
 
 from .. import DeeplayModule, Layer, LayerList, MultiLayerPerceptron
-from . import LayerSkipNormalization, MultiheadSelfAttention
+from . import LayerDropoutSkipNormalization, MultiheadSelfAttention
 
 from deeplay.blocks.sequential import SequentialBlock
 from deeplay import Sequential
@@ -107,6 +107,7 @@ class TransformerEncoderLayer(DeeplayModule):
         hidden_features: Sequence[Optional[int]],
         out_features: int,
         num_heads: int,
+        dropout: float = 0.0,
     ):
         super().__init__()
 
@@ -114,6 +115,7 @@ class TransformerEncoderLayer(DeeplayModule):
         self.hidden_features = hidden_features
         self.out_features = out_features
         self.num_heads = num_heads
+        self.dropout = dropout
 
         if out_features <= 0:
             raise ValueError(
@@ -137,23 +139,27 @@ class TransformerEncoderLayer(DeeplayModule):
                 SequentialBlock(
                     # First sub-block is multihead self-attention followed by
                     # skip connection and normalization.
-                    multihead=LayerSkipNormalization(
+                    multihead=LayerDropoutSkipNormalization(
                         layer=MultiheadSelfAttention(
                             f_out,
                             num_heads,
-                            projection=Layer(nn.LazyLinear, f_out)
-                            if f_in != f_out
-                            else Layer(nn.Identity),
+                            projection=(
+                                Layer(nn.Linear, f_in, f_out)
+                                if f_in != f_out
+                                else Layer(nn.Identity)
+                            ),
                         ),
+                        dropout=Layer(nn.Dropout, dropout),
                         skip=Add(),
                         normalization=Layer(nn.LayerNorm, f_out),
                     ),
                     # Second sub-block is feed forward followed by skip connection
                     # and normalization
-                    feed_forward=LayerSkipNormalization(
+                    feed_forward=LayerDropoutSkipNormalization(
                         layer=MultiLayerPerceptron(
                             f_out, [f_out], f_out, flatten_input=False
                         ),
+                        dropout=Layer(nn.Dropout, dropout),
                         skip=Add(),
                         normalization=Layer(nn.LayerNorm, f_out),
                     ),
@@ -173,7 +179,6 @@ class TransformerEncoderLayer(DeeplayModule):
         hidden_features: Optional[List[int]] = None,
         out_features: Optional[int] = None,
         num_heads: Optional[int] = None,
-    ) -> None:
-        ...
+    ) -> None: ...
 
     configure = DeeplayModule.configure

--- a/deeplay/components/transformer/satt.py
+++ b/deeplay/components/transformer/satt.py
@@ -48,9 +48,9 @@ class MultiheadSelfAttention(DeeplayModule):
         y, attn = self.attention(x, x, x, attn_mask=attn_mask)
 
         if self.return_attn:
-            return y, attn, x
+            return y, attn
         else:
-            return y, x
+            return y
 
     def _fetch_attn_mask(self, batch_index):
         """Fetch attention mask for 2D tensor. The mask is a square matrix with


### PR DESCRIPTION
This pull request introduces the LayerDropoutSkipNormalization block to Transformer models. This block is flexible and allows for easy changes to the order of its components. It also supports both Tensor inputs and dictionaries.