### PR TITLE
Integration methods and classes for deeptrack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,6 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        install-deeplay: [true, false]
-        install-tensorflow: [true, false]
-        install-tensorflow-probability: [true, false]
 
     steps:
       - uses: actions/checkout@v3
@@ -32,15 +29,6 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install flake8
           python -m pip install -r requirements.txt
-          if ${{ matrix.install-tensorflow }}; then
-            python -m pip install tensorflow
-          fi
-          if ${{ matrix.install-tensorflow-probability }}; then
-            python -m pip install tensorflow-probability
-          fi
-          if ${{ matrix.install-deeplay }}; then
-            python -m pip install deeplay
-          fi
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names
@@ -49,4 +37,4 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with unittest
         run: |
-          python -m unittest deeptrack.test
+          python -m unittest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,10 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest, windows-latest]
+        install-deeplay: [true, false]
         install-tensorflow: [true, false]
         install-tensorflow-probability: [true, false]
-        install-deeplay: [true, false]
+
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,37 +5,47 @@ name: Python package
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: ["develop"]
   pull_request:
-    branches: [ "develop" ]
+    branches: ["develop"]
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest, windows-latest]
-
+        install-tensorflow: [true, false]
+        install-tensorflow-probability: [true, false]
+        install-deeplay: [true, false]
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install flake8
-        python -m pip install -r requirements.txt
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with unittest
-      run: |
-        python -m unittest 
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install flake8
+          python -m pip install -r requirements.txt
+          if ${{ matrix.install-tensorflow }}; then
+            python -m pip install tensorflow
+          fi
+          if ${{ matrix.install-tensorflow-probability }}; then
+            python -m pip install tensorflow-probability
+          fi
+          if ${{ matrix.install-deeplay }}; then
+            python -m pip install deeplay
+          fi
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Test with unittest
+        run: |
+          python -m unittest deeptrack.test

--- a/deeplay/applications/application.py
+++ b/deeplay/applications/application.py
@@ -1,31 +1,137 @@
 import copy
-from typing import (
-    Callable,
-    Iterator,
-    Tuple,
-    Literal,
-    Optional,
-    Dict,
-    TypeVar,
-    Sequence,
-    Union,
-)
+import logging
+from typing import (Callable, Dict, Iterator, Literal, Optional, Sequence,
+                    Tuple, TypeVar, Union)
 
 import lightning as L
+import matplotlib.pyplot as plt
+import numpy as np
 import torch
 import torch.nn as nn
 import torchmetrics as tm
+import tqdm
+from lightning.pytorch.callbacks import RichProgressBar
 from torch.nn.modules.module import Module
 
+import deeplay as dl
 from deeplay import DeeplayModule, Optimizer
 
-import torchmetrics as tm
-import copy
+logging.getLogger("lightning.pytorch.utilities.rank_zero").setLevel(logging.WARNING)
+logging.getLogger("lightning.pytorch.accelerators.cuda").setLevel(logging.WARNING)
 
 T = TypeVar("T")
 
+class LogHistory(L.Callback):
+    """A keras-like history callback for lightning. Keeps track of metrics and losses during training and validation.
+    
+    Example:
+    >>> history = LogHistory()
+    >>> trainer = dl.Trainer(callbacks=[history])
+    >>> trainer.fit(model, train_dataloader, val_dataloader)
+    >>> history.history {"train_loss_epoch": {"value": [0.1, 0.2, 0.3], "epoch": [0, 1, 2], "step": [0, 100, 200]}}
+    """
+
+    @property
+    def history(self):
+        return {key: 
+                {
+                    "value": [item["value"] for item in value],
+                    "epoch": [item["epoch"] for item in value],
+                    "step": [item["step"] for item in value]
+                }
+                for key, value in self._history.items()}
+
+    @property
+    def step_history(self):
+        return {key: 
+                {
+                    "value": [item["value"] for item in value],
+                    "epoch": [item["epoch"] for item in value],
+                    "step": [item["step"] for item in value]
+                }
+                for key, value in self._step_history.items()}
+    
+    def __init__(self):
+        self._history = {}
+        self._step_history = {}
+
+    def on_train_batch_end(self, trainer: dl.Trainer, *args, **kwargs) -> None:
+        for key, value in trainer.callback_metrics.items():
+            if key.endswith("_step"):
+                self._step_history.setdefault(key, []).append(self._logitem(trainer, value))
+
+    def on_train_epoch_end(self, trainer: dl.Trainer, *args, **kwargs) -> None:
+        for key, value in trainer.callback_metrics.items():
+            if key.startswith("train") and key.endswith("_epoch"):
+                self._history.setdefault(key, []).append(self._logitem(trainer, value))
+    
+    def on_validation_epoch_end(self, trainer: dl.Trainer, *args, **kwargs) -> None:
+        for key, value in trainer.callback_metrics.items():
+            if key.startswith("val") and key.endswith("_epoch"):
+                self._history.setdefault(key, []).append(self._logitem(trainer, value))
+
+    def _logitem(self, trainer, value):
+        if isinstance(value, torch.Tensor):
+            value = value.item()
+        return {
+            "epoch": trainer.current_epoch,
+            "step": trainer.global_step,
+            "value": value
+        }
+
+    def plot(self, *args, yscale="log", **kwargs):
+        """Plot the history of the metrics and losses.
+        """
+
+        history = self.history
+        step_history = self.step_history
+        
+        keys = list(history.keys())
+        keys = [key.replace("val", "").replace("train", "") for key in keys]
+        unique_keys = list(set(keys))
+        # sort unique keys same as keys
+        unique_keys.sort(key=lambda x: keys.index(x))
+        keys = unique_keys
+
+        max_width = 3
+        rows = len(keys) // max_width + 1
+        width = min(len(keys), max_width)
+
+        fig, axes = plt.subplots(rows, width, figsize=(15, 5 * rows))
+
+        if len(keys) == 1:
+            axes = np.array([[axes]])
+
+        for ax, key in zip(axes.ravel(), keys):
+            train_key = "train" + key
+            val_key = "val" + key
+            step_key = ("train" + key).replace("epoch", "step")
+
+            
+            if step_key in step_history:
+                ax.plot(step_history[step_key]["step"], step_history[step_key]["value"], label=step_key, color="C1", alpha=0.25)
+            if train_key in history:
+                step = np.array(history[train_key]["step"])
+                step[1:] = step[1:] - (step[1:] - step[:-1]) / 2
+                step[0] /= 2
+                marker_kwargs = dict(marker="o", markerfacecolor="white", markeredgewidth=1.5) if len(step) < 20 else {}
+                ax.plot(step, history[train_key]["value"], label=train_key, color="C1", **marker_kwargs)
+
+            if val_key in history:
+                marker_kwargs = dict(marker="d", markerfacecolor="white", markeredgewidth=1.5) if len(step) < 20 else {}
+                ax.plot(history[val_key]["step"], history[val_key]["value"], label=val_key, color="C3", linestyle="--", **marker_kwargs)
+            
+            ax.set_title(key.replace("_", " ").replace("epoch", "").strip().capitalize())
+            ax.set_xlabel("Step")
+
+            ax.legend()
+            ax.set_yscale(yscale)
+        
+        return fig, axes
+
 
 class Application(DeeplayModule, L.LightningModule):
+
     def __init__(
         self,
         loss: Optional[Union[nn.Module, Callable[..., torch.Tensor]]] = None,
@@ -58,6 +164,125 @@ class Application(DeeplayModule, L.LightningModule):
 
     def forward(self, *args, **kwargs):
         raise NotImplementedError
+
+    def fit(self, 
+            train_data,
+            val_data=None,
+            max_epochs=None, 
+            batch_size=32, 
+            steps_per_epoch=100,
+            replace=False, 
+            val_batch_size=None, 
+            val_steps_per_epoch=10,
+            callbacks=[],
+            **kwargs) -> LogHistory:
+        """Train the model on the training data.
+
+        Train the model on the training data, with optional validation data.
+
+        Parameters
+        ----------
+        max_epochs : int
+            The maximum number of epochs to train the model.
+        batch_size : int
+            The batch size to use for training.
+        steps_per_epoch : int
+            The number of steps per epoch (used if train_data is a Feature).
+        replace : bool or float
+            Whether to replace the data after each epoch (used if train_data is a Feature).
+            If a float, the data is replaced with the given probability.
+        val_batch_size : int
+            The batch size to use for validation. If None, the training batch size is used.
+        val_steps_per_epoch : int
+            The number of steps per epoch for validation.
+        callbacks : list
+            A list of callbacks to use during training.
+        permute_target_channels : bool or "auto"
+            Whether to permute the target channels to channel first. If "auto", the model will
+            attempt to infer the correct permutation based on the input and target shapes.
+        **kwargs
+            Additional keyword arguments to pass to the trainer.
+        """        
+
+        val_batch_size = val_batch_size or batch_size
+        val_steps_per_epoch = val_steps_per_epoch or 10
+        train_data = self.create_data(train_data, batch_size, steps_per_epoch, replace)
+        val_data = self.create_data(val_data, val_batch_size, val_steps_per_epoch, False) if val_data else None
+        
+        history = LogHistory()
+        progressbar = RichProgressBar()
+        
+        callbacks = callbacks + [history, progressbar]
+        trainer = dl.Trainer(max_epochs=max_epochs, callbacks=callbacks, **kwargs)
+
+        train_dataloader = torch.utils.data.DataLoader(train_data, batch_size=batch_size, shuffle=True)
+        
+        if not self._has_built:
+            self.build()
+
+        self.train()
+        if val_data:
+            val_dataloader = torch.utils.data.DataLoader(val_data, batch_size=val_batch_size, shuffle=False) if val_data else None
+            trainer.fit(self, train_dataloader, val_dataloader)
+        else:
+            trainer.fit(self, train_dataloader)
+        self.eval()
+        return history
+
+    def test(self, 
+             data, 
+             metrics: Union[tm.Metric, Tuple[str, tm.Metric], Sequence[Union[tm.Metric, Tuple[str, tm.Metric]]], Dict[str, tm.Metric]],
+             batch_size: int = 32):
+        """Test the model on the given data.
+
+        Test the model on the given data, using the given metrics. Metrics can be
+        given as a single metric, a tuple of name and metric, a sequence of metrics
+        (or tuples of name and metric) or a dictionary of metrics. In the case of
+        tuples, the name is used as the key in the returned dictionary. In the case
+        of metrics, the name of the metric is used as the key in the returned dictionary.
+
+        Parameters
+        ----------
+        data : data-like
+            The data to test the model on. Can be a Feature, a torch.utils.data.Dataset, a tuple of tensors, a tensor or a numpy array.
+        metrics : metric-like
+            The metrics to use for testing. Can be a single metric, a tuple of name and metric, a sequence of metrics (or tuples of name and metric) or a dictionary of metrics.
+        batch_size : int
+            The batch size to use for testing.
+        """
+
+        device = self.trainer.strategy.root_device
+        self.to(device)
+        test_data = self.create_data(data)
+        test_dataloader = torch.utils.data.DataLoader(test_data, batch_size=batch_size, shuffle=True)
+
+        dict_metrics: Dict[str, tm.Metric]
+        if isinstance(metrics, tm.Metric):
+            dict_metrics = {metrics._get_name(): metrics}
+        elif isinstance(metrics, tuple):
+            dict_metrics = {metrics[0]: metrics[1]}
+        elif isinstance(metrics, list):
+            m = {}
+            for metric in metrics:
+                if isinstance(metric, tm.Metric):
+                    m[metric._get_name()] = metric
+                elif isinstance(metric, tuple):
+                    m[metric[0]] = metric[1]
+            dict_metrics = m
+        else:
+            dict_metrics = {k: v for k, v in metrics.items()}
+
+        for (x, y) in tqdm.tqdm(test_dataloader):
+            y_hat = self(x.to(device))
+            for metric in dict_metrics.values():
+                metric.to(device)
+                metric.update(y_hat.to(device), y.to(device))
+        
+        return {name: dict_metrics[name].compute() for name in dict_metrics}
+
+    def __call__(self, *args, **kwargs):
+        args = [self._maybe_to_channel_first(arg) for arg in args]
+        return super().__call__(*args, **kwargs)
 
     def compute_loss(self, y_hat, y) -> Union[torch.Tensor, Dict[str, torch.Tensor]]:
         if self.loss:
@@ -198,13 +423,14 @@ class Application(DeeplayModule, L.LightningModule):
         ]
 
     def train_preprocess(self, batch):
-        return batch
+        x, y = batch
+        x = self._maybe_to_channel_first(x)
+        y = self._maybe_to_channel_first(y)
+        
+        return x, y
 
-    def val_preprocess(self, batch):
-        return batch
-
-    def test_preprocess(self, batch):
-        return batch
+    val_preprocess = train_preprocess
+    test_preprocess = train_preprocess
 
     def _provide_paramaters_if_has_none(self, optimizer):
         if isinstance(optimizer, Optimizer):
@@ -231,3 +457,45 @@ class Application(DeeplayModule, L.LightningModule):
         ]
 
         yield from (not_optimizers + optimizers)
+    
+    def create_data(self, data, batch_size=32, steps_per_epoch=100, replace=False, **kwargs):
+        """Create a torch Dataset from data. If data is a Feature, it will create a Dataset with the feature.
+        """
+        if isinstance(data, np.ndarray):
+            data = torch.from_numpy(data)
+            return self._maybe_to_channel_first(data)
+        
+        if isinstance(data, torch.Tensor):
+            return data
+
+        if isinstance(data, torch.utils.data.Dataset):
+            return data
+
+        if isinstance(data, (tuple, list)):
+            datas = [self.create_data(d) for d in data]
+            return torch.utils.data.TensorDataset(*datas)
+        
+        # check if deeptrack object
+        if hasattr(data, "__module__") and data.__module__.startswith("deeptrack"):
+            import deeptrack as dt
+            if isinstance(data, dt.Feature):
+                return dt.pytorch.Dataset(data, 
+                                          length=batch_size*steps_per_epoch, replace=replace)
+            elif isinstance(data, dt.pytorch.Dataset):
+                return data
+        
+        raise ValueError(f"Data type {type(data)} not supported")
+    
+    @staticmethod
+    def _maybe_to_channel_first(x, other=None):
+        
+        if not isinstance(x, np.ndarray):
+            return x
+        
+        if x.ndim <= 2:
+            return x
+        
+        if x.dtype in [torch.int8, torch.int16, torch.int32, torch.int64]:
+            return x
+        
+        return np.moveaxis(x, -1, 1)

--- a/deeplay/applications/classification/binary.py
+++ b/deeplay/applications/classification/binary.py
@@ -36,8 +36,12 @@ class BinaryClassifier(Application):
         def params(self):
             return self.model.parameters()
 
+    
     def compute_loss(self, y_hat, y):
-        return self.loss(y_hat, y)
+        if isinstance(self.loss, (torch.nn.BCELoss, torch.nn.BCEWithLogitsLoss)):
+            y = y.float()
+        return super().compute_loss(y_hat, y)
+
 
     def forward(self, x):
         return self.model(x)

--- a/deeplay/module.py
+++ b/deeplay/module.py
@@ -650,8 +650,6 @@ class DeeplayModule(nn.Module, metaclass=ExtendedConstructorMeta):
         if args:
             for arg in args:
                 assert len(arg) == len(x), "All inputs must have the same length."
-        if len(x) < batch_size:
-            return self.forward(x, *args)
 
         if device is None:
             device = self.device

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+matplotlib
 lightning
 torchmetrics
 torchvision


### PR DESCRIPTION
Introduces many convenience integration methods to the `Application` class (and its subclasses) for integrating with deeptrack pipelines, but also just general convenience. There are some pretty major design decisions here, so we should all be on the same page.

# Major decision, automatic conversion to channel first

From now, it will be possible to directly pass `np.ndarrays` and `deeptrack.Feature`s to some deeplay methods. 

1. `deeplay` will assume that `numpy.ndarrays` either given directly or produced by deeptrack features are _channel last_, and automatically convert them to channel first. We can, if this proves troublesome in the future, give to option to disable this behavior.
2. Rule 1. does not apply if the data type is `integer`. Why? Because torch decided that CrossEntropyLoss targets should have no channels. To my knowledge, there is no `float` loss that does not match the shape of `y_hat`. 
3. `torch.Tensor`s will not be permuted. So, if one does the work themselves to convert to ttorch tensors, you will not run into any unexpected conversions.

Why do we need to do this? We don't, really. But it i highly unintuitive that to packages that are designed to work together requires the user to do manual permuting of channels back and forth to work. 

Moreover, we attempt to do automatic dtype conversions if possible. In general, any float will be converted to the default torch float, and any int will be converted to `long`. Finally, because `torch` decided to make things hard, for `BCEloss` and `BCELossWithLogits` we automatically convert the targets to `float`. 

The idea is not to always be correct, but to, in the cases we know what the correct dtype is, we perform the conversion. If we are not sure, we leave it to the user.

Since all of this only applies to non-tensors, no existing code should be affected.

# New shiny things!

With that out of the way, let's go through the new methods.

## `Application.fit`

This is a keras-like fit method for maximum convenience. Here's an example:

```py
model = dl.CategoricalClassifier(net)
model.fit(
    train_data,
    max_epochs=100,
    batch_size=32,
    val_data=val_data,
    val_batch_size=256
)
```

Here, train_data and val_data can be any of:
- DataLoader
- torch Dataset
- deeptrack Dataset
- deeptrack Feature (pipeline)
- tuple of ndarrays or tensors

For Feature's, specifically, you can provide the additional kwargs
- `steps_per_epoch`
- `val_steps_per_epoch`
since features are unsized.

All additional kwargs will be passed to the trainer, so you can still set conventional trainer kwargs like `callbacks`, `accelerator` etc. Moreover, it uses the rich progressbar, which looks good on all platforms, unlike the nbwidget one which is awful in vscode.

## `LogHistory`

Missed the history object from keras? It's back! But better, kinda. It will automatically be returned by `Application.fit`, but you can also just provide it as a `callback` to the trainer. It has two properties and a plot method. For most cases, it should be enough to access the plot method:

![image](https://github.com/DeepTrackAI/deeplay/assets/41636530/7f318e88-d3db-4662-9cf6-7684fed19d65)

A nice little plot made with the LogHistory object.

You can also access `h.history` and `h.step_history`. They contain the `on_epoch` metrics and the `on_step` metrics respectively. They are given in the format 
```py
{
   metric_name: {
       "value": [0.6, 0.5, 0.4, ...],
       "step": [0, 100, 200, ...],
       "epoch": [0, 1, 2, ...]
   }
}
```

## `Application.test`

A frustration for me was that you could only do `trainer.test` for metrics that you defined upon creating the model with `metrics=[...]`. With this, you can test any metrics:

```py
f1 = tm.F1Score(task="binary")
confusion_matrix = tm.ConfusionMatrix(task="binary")
ROC = tm.ROC(task="binary")

results = model.test(test, metrics={"f1": f1, "confusion_matrix": confusion_matrix, "roc": ROC})
```

Here, metrics can be provided in any of the following formats, but will always be returned as a dict:
- dict
- tm.Metric (output key is .__name__)
- tuple (key, metric)
- a list of the previous two

