### PR TITLE
Update default trainer to use rich progress bar and history

### DIFF
--- a/deeplay/__init__.py
+++ b/deeplay/__init__.py
@@ -1,14 +1,12 @@
 import warnings
 
 # temporary imports until we implement our own
-
-from lightning import Trainer
 from torch.utils.data import DataLoader
 
 # Filter out warnings from lazy torch modules
 warnings.filterwarnings("ignore", category=UserWarning, module="torch.nn.modules.lazy")
 
-
+from .trainer import Trainer
 from .meta import ExtendedConstructorMeta
 from .module import DeeplayModule
 from .list import LayerList, Sequential, Parallel
@@ -17,4 +15,5 @@ from .blocks import *
 from .components import *
 from .applications import *
 from .models import *
-from . import decorators, activelearning, initializers
+
+from . import decorators, activelearning, initializers, callbacks

--- a/deeplay/applications/application.py
+++ b/deeplay/applications/application.py
@@ -21,158 +21,17 @@ import torch
 import torch.nn as nn
 import torchmetrics as tm
 import tqdm
-from lightning.pytorch.callbacks import RichProgressBar
-from lightning.pytorch.callbacks.progress.rich_progress import RichProgressBarTheme
 from torch.nn.modules.module import Module
 from torch_geometric.data import Data
 
 import deeplay as dl
 from deeplay import DeeplayModule, Optimizer
+from deeplay.callbacks import RichProgressBar, LogHistory
 
 logging.getLogger("lightning.pytorch.utilities.rank_zero").setLevel(logging.WARNING)
 logging.getLogger("lightning.pytorch.accelerators.cuda").setLevel(logging.WARNING)
 
 T = TypeVar("T")
-
-
-class LogHistory(L.Callback):
-    """A keras-like history callback for lightning. Keeps track of metrics and losses during training and validation.
-
-    Example:
-    >>> history = LogHistory()
-    >>> trainer = dl.Trainer(callbacks=[history])
-    >>> trainer.fit(model, train_dataloader, val_dataloader)
-    >>> history.history {"train_loss_epoch": {"value": [0.1, 0.2, 0.3], "epoch": [0, 1, 2], "step": [0, 100, 200]}}
-    """
-
-    @property
-    def history(self):
-        return {
-            key: {
-                "value": [item["value"] for item in value],
-                "epoch": [item["epoch"] for item in value],
-                "step": [item["step"] for item in value],
-            }
-            for key, value in self._history.items()
-        }
-
-    @property
-    def step_history(self):
-        return {
-            key: {
-                "value": [item["value"] for item in value],
-                "epoch": [item["epoch"] for item in value],
-                "step": [item["step"] for item in value],
-            }
-            for key, value in self._step_history.items()
-        }
-
-    def __init__(self):
-        self._history = {}
-        self._step_history = {}
-
-    def on_train_batch_end(self, trainer: dl.Trainer, *args, **kwargs) -> None:
-        for key, value in trainer.callback_metrics.items():
-            if key.endswith("_step"):
-                self._step_history.setdefault(key, []).append(
-                    self._logitem(trainer, value)
-                )
-
-    def on_train_epoch_end(self, trainer: dl.Trainer, *args, **kwargs) -> None:
-        for key, value in trainer.callback_metrics.items():
-            if key.startswith("train") and key.endswith("_epoch"):
-                self._history.setdefault(key, []).append(self._logitem(trainer, value))
-
-    def on_validation_epoch_end(self, trainer: dl.Trainer, *args, **kwargs) -> None:
-        for key, value in trainer.callback_metrics.items():
-            if key.startswith("val") and key.endswith("_epoch"):
-                self._history.setdefault(key, []).append(self._logitem(trainer, value))
-
-    def _logitem(self, trainer, value):
-        if isinstance(value, torch.Tensor):
-            value = value.item()
-        return {
-            "epoch": trainer.current_epoch,
-            "step": trainer.global_step,
-            "value": value,
-        }
-
-    def plot(self, *args, yscale="log", **kwargs):
-        """Plot the history of the metrics and losses."""
-
-        history = self.history
-        step_history = self.step_history
-
-        keys = list(history.keys())
-        keys = [key.replace("val", "").replace("train", "") for key in keys]
-        unique_keys = list(set(keys))
-        # sort unique keys same as keys
-        unique_keys.sort(key=lambda x: keys.index(x))
-        keys = unique_keys
-
-        max_width = 3
-        rows = len(keys) // max_width + 1
-        width = min(len(keys), max_width)
-
-        fig, axes = plt.subplots(rows, width, figsize=(15, 5 * rows))
-
-        if len(keys) == 1:
-            axes = np.array([[axes]])
-
-        for ax, key in zip(axes.ravel(), keys):
-            train_key = "train" + key
-            val_key = "val" + key
-            step_key = ("train" + key).replace("epoch", "step")
-
-            if step_key in step_history:
-                ax.plot(
-                    step_history[step_key]["step"],
-                    step_history[step_key]["value"],
-                    label=step_key,
-                    color="C1",
-                    alpha=0.25,
-                )
-            if train_key in history:
-                step = np.array(history[train_key]["step"])
-                step[1:] = step[1:] - (step[1:] - step[:-1]) / 2
-                step[0] /= 2
-                marker_kwargs = (
-                    dict(marker="o", markerfacecolor="white", markeredgewidth=1.5)
-                    if len(step) < 20
-                    else {}
-                )
-                ax.plot(
-                    step,
-                    history[train_key]["value"],
-                    label=train_key,
-                    color="C1",
-                    **marker_kwargs,
-                )
-
-            if val_key in history:
-                marker_kwargs = (
-                    dict(marker="d", markerfacecolor="white", markeredgewidth=1.5)
-                    if len(step) < 20
-                    else {}
-                )
-                ax.plot(
-                    history[val_key]["step"],
-                    history[val_key]["value"],
-                    label=val_key,
-                    color="C3",
-                    linestyle="--",
-                    **marker_kwargs,
-                )
-
-            ax.set_title(
-                key.replace("_", " ").replace("epoch", "").strip().capitalize()
-            )
-            ax.set_xlabel("Step")
-
-            ax.legend()
-            ax.set_yscale(yscale)
-
-        return fig, axes
 
 
 class Application(DeeplayModule, L.LightningModule):
@@ -261,8 +120,7 @@ class Application(DeeplayModule, L.LightningModule):
         )
 
         history = LogHistory()
-        theme = RichProgressBarTheme(metrics_format=".3g")
-        progressbar = RichProgressBar(theme=theme)
+        progressbar = RichProgressBar()
 
         callbacks = callbacks + [history, progressbar]
         trainer = dl.Trainer(max_epochs=max_epochs, callbacks=callbacks, **kwargs)
@@ -577,7 +435,6 @@ class Application(DeeplayModule, L.LightningModule):
         else:
             return optimizer
 
-
     def _apply_batch_transfer_handler(
         self, batch: Any, device: Optional[torch.device] = None, dataloader_idx: int = 0
     ) -> Any:
@@ -620,4 +477,3 @@ class Application(DeeplayModule, L.LightningModule):
             kwargs.update({"batch_size": self._current_batch_size})
 
         super().log(name, value, **kwargs)
-

--- a/deeplay/callbacks/__init__.py
+++ b/deeplay/callbacks/__init__.py
@@ -1,0 +1,2 @@
+from .progress import RichProgressBar
+from .history import LogHistory

--- a/deeplay/callbacks/history.py
+++ b/deeplay/callbacks/history.py
@@ -1,0 +1,149 @@
+import lightning as L
+import torch
+import numpy as np
+import matplotlib.pyplot as plt
+from typing import Dict, List, Union, Literal
+
+
+class LogHistory(L.Callback):
+    """A keras-like history callback for lightning. Keeps track of metrics and losses during training and validation.
+
+    Example:
+    >>> history = LogHistory()
+    >>> trainer = dl.Trainer(callbacks=[history])
+    >>> trainer.fit(model, train_dataloader, val_dataloader)
+    >>> history.history {"train_loss_epoch": {"value": [0.1, 0.2, 0.3], "epoch": [0, 1, 2], "step": [0, 100, 200]}}
+    """
+
+    @property
+    def history(
+        self,
+    ) -> Dict[str, Dict[Literal["value", "epoch", "step"], List[Union[float, int]]]]:
+        return {
+            key: {
+                "value": [item["value"] for item in value],
+                "epoch": [item["epoch"] for item in value],
+                "step": [item["step"] for item in value],
+            }
+            for key, value in self._history.items()
+        }
+
+    @property
+    def step_history(
+        self,
+    ) -> Dict[str, Dict[Literal["value", "epoch", "step"], List[Union[float, int]]]]:
+        return {
+            key: {
+                "value": [item["value"] for item in value],
+                "epoch": [item["epoch"] for item in value],
+                "step": [item["step"] for item in value],
+            }
+            for key, value in self._step_history.items()
+        }
+
+    def __init__(self):
+        self._history = {}
+        self._step_history = {}
+
+    def on_train_batch_end(self, trainer, *args, **kwargs) -> None:
+        for key, value in trainer.callback_metrics.items():
+            if key.endswith("_step"):
+                self._step_history.setdefault(key, []).append(
+                    self._logitem(trainer, value)
+                )
+
+    def on_train_epoch_end(self, trainer, *args, **kwargs) -> None:
+        for key, value in trainer.callback_metrics.items():
+            if key.startswith("train") and key.endswith("_epoch"):
+                self._history.setdefault(key, []).append(self._logitem(trainer, value))
+
+    def on_validation_epoch_end(self, trainer, *args, **kwargs) -> None:
+        for key, value in trainer.callback_metrics.items():
+            if key.startswith("val") and key.endswith("_epoch"):
+                self._history.setdefault(key, []).append(self._logitem(trainer, value))
+
+    def _logitem(self, trainer, value):
+        if isinstance(value, torch.Tensor):
+            value = value.item()
+        return {
+            "epoch": trainer.current_epoch,
+            "step": trainer.global_step,
+            "value": value,
+        }
+
+    def plot(self, *args, yscale="log", **kwargs):
+        """Plot the history of the metrics and losses."""
+
+        history = self.history
+        step_history = self.step_history
+
+        keys = list(history.keys())
+        keys = [key.replace("val", "").replace("train", "") for key in keys]
+        unique_keys = list(set(keys))
+        # sort unique keys same as keys
+        unique_keys.sort(key=lambda x: keys.index(x))
+        keys = unique_keys
+
+        max_width = 3
+        rows = len(keys) // max_width + 1
+        width = min(len(keys), max_width)
+
+        fig, axes = plt.subplots(rows, width, figsize=(15, 5 * rows))
+
+        if len(keys) == 1:
+            axes = np.array([[axes]])
+
+        for ax, key in zip(axes.ravel(), keys):
+            train_key = "train" + key
+            val_key = "val" + key
+            step_key = ("train" + key).replace("epoch", "step")
+
+            if step_key in step_history:
+                ax.plot(
+                    step_history[step_key]["step"],
+                    step_history[step_key]["value"],
+                    label=step_key,
+                    color="C1",
+                    alpha=0.25,
+                )
+            if train_key in history:
+                step = np.array(history[train_key]["step"])
+                step[1:] = step[1:] - (step[1:] - step[:-1]) / 2
+                step[0] /= 2
+                marker_kwargs = (
+                    dict(marker="o", markerfacecolor="white", markeredgewidth=1.5)
+                    if len(step) < 20
+                    else {}
+                )
+                ax.plot(
+                    step,
+                    history[train_key]["value"],
+                    label=train_key,
+                    color="C1",
+                    **marker_kwargs,
+                )
+
+            if val_key in history:
+                marker_kwargs = (
+                    dict(marker="d", markerfacecolor="white", markeredgewidth=1.5)
+                    if len(step) < 20
+                    else {}
+                )
+                ax.plot(
+                    history[val_key]["step"],
+                    history[val_key]["value"],
+                    label=val_key,
+                    color="C3",
+                    linestyle="--",
+                    **marker_kwargs,
+                )
+
+            ax.set_title(
+                key.replace("_", " ").replace("epoch", "").strip().capitalize()
+            )
+            ax.set_xlabel("Step")
+
+            ax.legend()
+            ax.set_yscale(yscale)
+
+        return fig, axes

--- a/deeplay/callbacks/progress.py
+++ b/deeplay/callbacks/progress.py
@@ -1,0 +1,21 @@
+from lightning.pytorch.callbacks.progress.rich_progress import (
+    RichProgressBar as RPB,
+    RichProgressBarTheme as RPBT,
+)
+
+
+class RichProgressBar(RPB):
+
+    def __init__(
+        self,
+        refresh_rate: int = 1,
+        leave: bool = False,
+        theme: RPBT = RPBT(metrics_format=".3g"),
+        console_kwargs=None,
+    ):
+        super().__init__(
+            refresh_rate=refresh_rate,
+            leave=leave,
+            theme=theme,
+            console_kwargs=console_kwargs,
+        )

--- a/deeplay/tests/test_trainer.py
+++ b/deeplay/tests/test_trainer.py
@@ -1,0 +1,69 @@
+from deeplay.trainer import Trainer
+from deeplay.callbacks import LogHistory, RichProgressBar
+from deeplay import Regressor, DataLoader
+from lightning.pytorch.callbacks.progress.tqdm_progress import TQDMProgressBar
+import unittest
+import torch.nn as nn
+import lightning as L
+import torch
+
+
+class TestTrainer(unittest.TestCase):
+    def test_trainer(self):
+        trainer = Trainer(callbacks=[LogHistory()])
+        self.assertIsInstance(trainer, Trainer)
+        self.assertIsInstance(trainer.callbacks[0], LogHistory)
+        self.assertIsInstance(
+            trainer.callbacks[1], RichProgressBar
+        )  # should be added by default
+
+    def test_trainer_explicit_progress_bar(self):
+        trainer = Trainer(callbacks=[LogHistory(), RichProgressBar()])
+        self.assertIsInstance(trainer, Trainer)
+        self.assertIsInstance(trainer.callbacks[0], LogHistory)
+        self.assertIsInstance(trainer.callbacks[1], RichProgressBar)
+
+    def test_trainer_explicit_progress_bar_tqdm(self):
+        trainer = Trainer(callbacks=[LogHistory(), TQDMProgressBar()])
+        self.assertIsInstance(trainer, Trainer)
+        self.assertIsInstance(trainer.callbacks[0], LogHistory)
+        self.assertIsInstance(trainer.callbacks[1], TQDMProgressBar)
+
+    def test_trainer_implicit_progress_bar_and_disable(self):
+        trainer = Trainer(callbacks=[LogHistory()], enable_progress_bar=False)
+        self.assertIsInstance(trainer, Trainer)
+        self.assertIsInstance(trainer.callbacks[0], LogHistory)
+
+    def test_fit(self):
+        trainer = Trainer(max_epochs=1)
+        model = Regressor(nn.Linear(1, 1))
+        X = torch.rand(100, 1)
+        y = torch.rand(100, 1)
+        dataset = torch.utils.data.TensorDataset(X, y)
+        train_dataloader = DataLoader(dataset, batch_size=32)
+        val_dataloader = DataLoader(dataset, batch_size=32)
+
+        trainer.fit(model, train_dataloader, val_dataloader)
+
+        self.assertIsInstance(trainer.history, LogHistory)
+        keys = set(trainer.history.history.keys())
+        self.assertTrue("train_loss_epoch" in keys)
+        self.assertTrue("val_loss_epoch" in keys)
+        step_keys = set(trainer.history.step_history.keys())
+        self.assertTrue("train_loss_step" in step_keys)
+
+    def test_fit_disabled_history(self):
+        trainer = Trainer(max_epochs=1)
+        trainer.disable_history()
+
+        model = Regressor(nn.Linear(1, 1))
+        X = torch.rand(100, 1)
+        y = torch.rand(100, 1)
+        dataset = torch.utils.data.TensorDataset(X, y)
+        train_dataloader = DataLoader(dataset, batch_size=32)
+        val_dataloader = DataLoader(dataset, batch_size=32)
+
+        trainer.fit(model, train_dataloader, val_dataloader)
+
+        with self.assertRaises(ValueError):
+            trainer.history

--- a/deeplay/trainer.py
+++ b/deeplay/trainer.py
@@ -1,0 +1,55 @@
+from datetime import timedelta
+from typing import Dict, List, Optional, Union
+
+from lightning import Callback, LightningDataModule
+from lightning import Trainer as pl_Trainer
+from lightning.fabric.utilities.types import _PATH
+from lightning.pytorch.callbacks.progress.progress_bar import ProgressBar
+from lightning.pytorch.trainer.connectors.callback_connector import _CallbackConnector
+from lightning.pytorch.utilities.types import EVAL_DATALOADERS, TRAIN_DATALOADERS
+
+from deeplay.callbacks import LogHistory, RichProgressBar
+
+
+class _DeeplayCallbackConnector(_CallbackConnector):
+    def _configure_progress_bar(self, enable_progress_bar: bool = True) -> None:
+        progress_bars = [
+            c for c in self.trainer.callbacks if isinstance(c, ProgressBar)
+        ]
+        if enable_progress_bar and not progress_bars:
+            self.trainer.callbacks.append(RichProgressBar())
+
+        # Not great. Should be in a separate configure method. However, this
+        # is arguably more stable to api changes in lightning.
+        log_histories = [c for c in self.trainer.callbacks if isinstance(c, LogHistory)]
+        if not log_histories:
+            self.trainer.callbacks.append(LogHistory())
+
+        return super()._configure_progress_bar(enable_progress_bar)
+
+
+class Trainer(pl_Trainer):
+
+    @property
+    def _callback_connector(self):
+        return self._callbacks_connector_internal
+
+    @_callback_connector.setter
+    def _callback_connector(self, value: _CallbackConnector):
+        self._callbacks_connector_internal = _DeeplayCallbackConnector(value.trainer)
+
+    @property
+    def history(self) -> LogHistory:
+        """Returns the history of the training process."""
+        for callback in self.callbacks:
+            if isinstance(callback, LogHistory):
+                return callback
+        raise ValueError("History object not found in callbacks")
+
+    def disable_history(self) -> None:
+        """Disables the history callback."""
+        for callback in self.callbacks:
+            if isinstance(callback, LogHistory):
+                self.callbacks.remove(callback)
+                return
+        raise ValueError("History object not found in callbacks")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ torch-geometric
 kornia
 scipy
 scikit-image
+rich


### PR DESCRIPTION
This PR adds QoL to the training. 

First, the training history can now always be accessed from the trainer:

```py
model = dl.Regressor(...)

trainer = dl.Trainer(...)
trainer.fit(model, ...)
trainer.history.plot()
```

Second, we move to using the RichProgressBar as the default. This is because it works much better with notebooks than the default TQDM