### PR TITLE
Bm/refactor/block-methods

### DIFF
--- a/deeplay/blocks/sequential.py
+++ b/deeplay/blocks/sequential.py
@@ -1,9 +1,12 @@
 import warnings
 
+from torch import nn
+
 from .block import Block
 
-from typing import List, Optional, overload, Any
+from typing import List, Optional, Union, overload, Any, Literal
 from ..module import DeeplayModule
+from deeplay.external import Layer
 
 
 class SequentialBlock(Block):
@@ -25,6 +28,194 @@ class SequentialBlock(Block):
             else:
                 setattr(self, name, kwargs[name])
                 self.order.append(name)
+
+    def append(self, layer: DeeplayModule, name: Optional[str] = None):
+        """Append a layer to the block, executing it after all the other layers.
+
+        Parameters
+        ----------
+        layer : DeeplayLayer
+            The layer to append.
+        name : Optional[str], optional
+            The name of the layer, by default None.
+            If None, the name of the layer will be the lowercase of its class name.
+        """
+        if name is None:
+            name = layer.__class__.__name__.lower()
+        self.configure(**{name: layer}, order=self.order + [name])
+
+    def prepend(self, layer: DeeplayModule, name: Optional[str] = None):
+        """Prepend a layer to the block, executing it before all the other layers.
+
+        Parameters
+        ----------
+        layer : DeeplayLayer
+            The layer to prepend.
+        name : Optional[str], optional
+            The name of the layer, by default None.
+            If None, the name of the layer will be the lowercase of its class name.
+        """
+        if name is None:
+            name = layer.__class__.__name__.lower()
+        self.configure(**{name: layer}, order=[name] + self.order)
+
+    def insert(self, layer: DeeplayModule, after: str, name: Optional[str] = None):
+        """Insert a layer to the block, executing it after a specific layer.
+
+        Parameters
+        ----------
+        layer : DeeplayLayer
+            The layer to insert.
+        after : str
+            The name of the layer after which the new layer will be executed.
+        name : Optional[str], optional
+            The name of the layer, by default None.
+
+        Raises
+        ------
+        ValueError
+            If the layer `after` is not found in the block.
+        """
+
+        if name is None:
+            name = layer.__class__.__name__.lower()
+        if after not in self.order:
+            raise ValueError(f"Layer `{after}` not found in the block.")
+        index = self.order.index(after) + 1
+        self.configure(
+            **{name: layer}, order=self.order[:index] + [name] + self.order[index:]
+        )
+
+    def remove(self, name: str, allow_missing: bool = False):
+        """Remove a layer from the block.
+
+        Parameters
+        ----------
+        name : str
+            The name of the layer to remove.
+        allow_missing : bool, optional
+            Whether to raise an error if the layer is not found in the block, by default False.
+
+        Raises
+        ------
+        ValueError
+            If the layer `name` is not found in the block and `allow_missing` is False.
+        """
+        if name not in self.order:
+            if not allow_missing:
+                raise ValueError(f"Layer `{name}` not found in the block.")
+            else:
+                return
+
+        self.configure(order=[n for n in self.order if n != name])
+
+    def append_dropout(self, p: float, name: Optional[str] = "dropout"):
+        """Append a dropout layer to the block.
+
+        Parameters
+        ----------
+        p : float
+            The dropout probability.
+        name : Optional[str], optional
+            The name of the dropout layer, by default "dropout".
+        """
+        self.append(Layer(nn.Dropout, p), name=name)
+
+    def prepend_dropout(self, p: float, name: Optional[str] = "dropout"):
+        """Prepend a dropout layer to the block.
+
+        Parameters
+        ----------
+        p : float
+            The dropout probability.
+        name : Optional[str], optional
+            The name of the dropout layer, by default "dropout".
+        """
+        self.prepend(Layer(nn.Dropout, p), name=name)
+
+    def insert_dropout(self, p: float, after: str, name: Optional[str] = "dropout"):
+        """Insert a dropout layer to the block.
+
+        Parameters
+        ----------
+        p : float
+            The dropout probability.
+        after : str
+            The name of the layer after which the dropout layer will be executed.
+        name : Optional[str], optional
+            The name of the dropout layer, by default "dropout".
+
+        Raises
+        ------
+        ValueError
+            If the layer `after` is not found in the block.
+        """
+        self.insert(Layer(nn.Dropout, p), after=after, name=name)
+
+    def remove_dropout(self, name: str = "dropout", allow_missing: bool = False):
+        """Remove a dropout layer from the block.
+
+        Parameters
+        ----------
+        name : str, optional
+            The name of the dropout layer to remove, by default "dropout".
+        allow_missing : bool, optional
+            Whether to raise an error if the dropout layer is not found in the block, by default False.
+
+        Raises
+        ------
+        ValueError
+            If the dropout layer `name` is not found in the block and `allow_missing` is False.
+        """
+        self.remove(name, allow_missing=allow_missing)
+
+    def set_dropout(
+        self,
+        p: float,
+        name: str = "dropout",
+        on_missing: Literal["append", "prepend", "insert"] = "append",
+        after: Optional[str] = None,
+    ):
+        """Set the dropout probability of a dropout layer.
+
+        Parameters
+        ----------
+        p : float
+            The dropout probability.
+        name : str, optional
+            The name of the dropout layer, by default "dropout".
+        on_missing : str, optional
+            The action to take if the dropout layer is not found in the block.
+            If "append", a new dropout layer will be appended to the block.
+            If "prepend", a new dropout layer will be prepended to the block.
+            If "insert", a new dropout layer will be inserted after the layer specified in `after`.
+            By default "append".
+        after : str, optional
+            The name of the layer after which the dropout layer will be executed if `on_missing` is "insert", by default None.
+
+        """
+
+        if on_missing != "insert" and after is not None:
+            warnings.warn("`after` is only used when `on_missing` is 'insert'.")
+
+        if name not in self.order:
+            if on_missing == "append":
+                self.append_dropout(p, name=name)
+            elif on_missing == "prepend":
+                self.prepend_dropout(p, name=name)
+            elif on_missing == "insert":
+                if after is None:
+                    raise ValueError(
+                        "You must specify the layer after which to insert the dropout layer."
+                    )
+                self.insert_dropout(p, after=after, name=name)
+            else:
+                raise ValueError(
+                    f"Invalid value for `on_missing`. Expected 'append', 'prepend', or 'insert', got {on_missing}."
+                )
+
+        else:
+            getattr(self, name).configure(p=p)
 
     def configure(self, *args, **kwargs):
         super().configure(*args, **kwargs)

--- a/deeplay/module.py
+++ b/deeplay/module.py
@@ -1098,6 +1098,7 @@ class Selection(DeeplayModule):
         for selection in self.selections:
             for item in selection:
                 s += ".".join(item) + "\n"
+        s = "Selection(\n" + s + ")"
         return s
 
     def list_names(self):
@@ -1196,13 +1197,56 @@ class Selection(DeeplayModule):
         )
 
     def configure(self, *args, **kwargs):
+        """Applies `DeeplayModule.configure` to all modules in the selection."""
         return self.all.configure(*args, **kwargs)
 
+    def replace(self, *args, **kwargs):
+        """Applies `DeeplayModule.replace` to all modules in the selection."""
+        return self.all.replace(*args, **kwargs)
+
     def log_output(self, key):
+        """Applies `DeeplayModule.log_output` to the first module in the selection."""
         return self.first.log_output(key)
 
     def log_input(self, key):
+        """Applies `DeeplayModule.log_input` to the first module in the selection."""
         return self.first.log_input(key)
+
+    def append(self, *args, **kwargs):
+        """Applies `SequentialBlock.append` to all modules in the selection."""
+        return self.all.append(*args, **kwargs)
+
+    def prepend(self, *args, **kwargs):
+        """Applies `SequentialBlock.prepend` to all modules in the selection."""
+        return self.all.prepend(*args, **kwargs)
+
+    def insert(self, *args, **kwargs):
+        """Applies `SequentialBlock.insert` to all modules in the selection."""
+        return self.all.insert(*args, **kwargs)
+
+    def remove(self, *args, **kwargs):
+        """Applies `SequentialBlock.remove` to all modules in the selection."""
+        return self.all.remove(*args, **kwargs)
+
+    def append_dropout(self, *args, **kwargs):
+        """Applies `SequentialBlock.append_dropout` to all modules in the selection."""
+        return self.all.append_dropout(*args, **kwargs)
+
+    def prepend_dropout(self, *args, **kwargs):
+        """Applies `SequentialBlock.prepend_dropout` to all modules in the selection."""
+        return self.all.prepend_dropout(*args, **kwargs)
+
+    def insert_dropout(self, *args, **kwargs):
+        """Applies `SequentialBlock.insert_dropout` to all modules in the selection."""
+        return self.all.insert_dropout(*args, **kwargs)
+
+    def remove_dropout(self, *args, **kwargs):
+        """Applies `SequentialBlock.remove_dropout` to all modules in the selection."""
+        return self.all.remove_dropout(*args, **kwargs)
+
+    def set_dropout(self, *args, **kwargs):
+        """Applies `SequentialBlock.set_dropout` to all modules in the selection."""
+        return self.all.set_dropout(*args, **kwargs)
 
 
 class _MethodForwarder:
@@ -1236,10 +1280,53 @@ class _MethodForwarder:
             return self._create_forwarder(name)
 
     def configure(self, *args, **kwargs):
+        """See `DeeplayModule.configure`."""
         return self._create_forwarder("configure")(*args, **kwargs)
 
+    def replace(self, *args, **kwargs):
+        """See `DeeplayModule.replace`."""
+        return self._create_forwarder("replace")(*args, **kwargs)
+
     def log_output(self, key):
+        """See `DeeplayModule.log_output`."""
         return self._create_forwarder("log_output")(key)
 
     def log_input(self, key):
+        """See `DeeplayModule.log_input`."""
         return self._create_forwarder("log_input")(key)
+
+    def append(self, *args, **kwargs):
+        """See `SequentialBlock.append`."""
+        return self._create_forwarder("append")(*args, **kwargs)
+
+    def prepend(self, *args, **kwargs):
+        """See `SequentialBlock.prepend`."""
+        return self._create_forwarder("prepend")(*args, **kwargs)
+
+    def insert(self, *args, **kwargs):
+        """See `SequentialBlock.insert`."""
+        return self._create_forwarder("insert")(*args, **kwargs)
+
+    def remove(self, *args, **kwargs):
+        """See `SequentialBlock.remove`."""
+        return self._create_forwarder("remove")(*args, **kwargs)
+
+    def append_dropout(self, *args, **kwargs):
+        """See `SequentialBlock.append_dropout`."""
+        return self._create_forwarder("append_dropout")(*args, **kwargs)
+
+    def prepend_dropout(self, *args, **kwargs):
+        """See `SequentialBlock.prepend_dropout`."""
+        return self._create_forwarder("prepend_dropout")(*args, **kwargs)
+
+    def insert_dropout(self, *args, **kwargs):
+        """See `SequentialBlock.insert_dropout`."""
+        return self._create_forwarder("insert_dropout")(*args, **kwargs)
+
+    def remove_dropout(self, *args, **kwargs):
+        """See `SequentialBlock.remove_dropout`."""
+        return self._create_forwarder("remove_dropout")(*args, **kwargs)
+
+    def set_dropout(self, *args, **kwargs):
+        """See `SequentialBlock.set_dropout`."""
+        return self._create_forwarder("set_dropout")(*args, **kwargs)

--- a/deeplay/tests/test_blocks.py
+++ b/deeplay/tests/test_blocks.py
@@ -1,0 +1,411 @@
+import unittest
+from deeplay import Block, SequentialBlock, Layer
+
+import torch
+import torch.nn as nn
+
+
+class TestBlock(unittest.TestCase):
+
+    def test_block(self):
+        block = Block(a=Layer(nn.Linear, 1, 2), b=Layer(nn.Linear, 2, 1))
+
+        self.assertIsInstance(block.a, Layer)
+        self.assertIsInstance(block.b, Layer)
+
+        created = block.create()
+
+        self.assertIsInstance(created.a, nn.Linear)
+        self.assertIsInstance(created.b, nn.Linear)
+
+        built = block.build()
+
+        self.assertIsInstance(built.a, nn.Linear)
+        self.assertIsInstance(built.b, nn.Linear)
+
+    def test_configure_block(self):
+        block = Block(a=Layer(nn.Linear, 1, 2), b=Layer(nn.Linear, 2, 1))
+        block.configure(b=Layer(nn.Conv2d, 1, 1, 1))
+
+        self.assertIsInstance(block.a, Layer)
+        self.assertIsInstance(block.b, Layer)
+
+        created = block.create()
+
+        self.assertIsInstance(created.a, nn.Linear)
+        self.assertIsInstance(created.b, nn.Conv2d)
+
+        built = block.build()
+
+        self.assertIsInstance(built.a, nn.Linear)
+        self.assertIsInstance(built.b, nn.Conv2d)
+
+
+class TestSequentalBlock(unittest.TestCase):
+
+    def test_sequential_block(self):
+        block = SequentialBlock(a=Layer(nn.Linear, 1, 2), b=Layer(nn.Linear, 2, 1))
+
+        self.assertIsInstance(block.a, Layer)
+        self.assertIsInstance(block.b, Layer)
+        self.assertListEqual(block.order, ["a", "b"])
+
+        created = block.create()
+
+        self.assertIsInstance(created.a, nn.Linear)
+        self.assertIsInstance(created.b, nn.Linear)
+        self.assertListEqual(created.order, ["a", "b"])
+
+        built = block.build()
+
+        self.assertIsInstance(built.a, nn.Linear)
+        self.assertIsInstance(built.b, nn.Linear)
+        self.assertListEqual(built.order, ["a", "b"])
+
+    def test_configure_sequential_block_order(self):
+        block = SequentialBlock(a=Layer(nn.Linear, 1, 2), b=Layer(nn.Linear, 2, 1))
+        block.configure(order=["b", "a"])
+
+        self.assertIsInstance(block.a, Layer)
+        self.assertIsInstance(block.b, Layer)
+        self.assertListEqual(block.order, ["b", "a"])
+
+        created = block.create()
+
+        self.assertIsInstance(created.a, nn.Linear)
+        self.assertIsInstance(created.b, nn.Linear)
+        self.assertListEqual(created.order, ["b", "a"])
+
+        built = block.build()
+
+        self.assertIsInstance(built.a, nn.Linear)
+        self.assertIsInstance(built.b, nn.Linear)
+        self.assertListEqual(built.order, ["b", "a"])
+
+    def test_configure_sequence_block(self):
+        block = SequentialBlock(a=Layer(nn.Linear, 1, 2), b=Layer(nn.Linear, 2, 1))
+        block.configure(b=Layer(nn.Conv2d, 1, 1, 1))
+
+        self.assertIsInstance(block.a, Layer)
+        self.assertIsInstance(block.b, Layer)
+        self.assertListEqual(block.order, ["a", "b"])
+
+        created = block.create()
+
+        self.assertIsInstance(created.a, nn.Linear)
+        self.assertIsInstance(created.b, nn.Conv2d)
+        self.assertListEqual(created.order, ["a", "b"])
+
+        built = block.build()
+
+        self.assertIsInstance(built.a, nn.Linear)
+        self.assertIsInstance(built.b, nn.Conv2d)
+        self.assertListEqual(built.order, ["a", "b"])
+
+    def test_configure_add_layer(self):
+        block = SequentialBlock(a=Layer(nn.Linear, 1, 2), b=Layer(nn.Linear, 2, 1))
+        block.configure(c=Layer(nn.Conv2d, 1, 1, 1), order=["a", "b", "c"])
+
+        self.assertIsInstance(block.a, Layer)
+        self.assertIsInstance(block.b, Layer)
+        self.assertIsInstance(block.c, Layer)
+        self.assertListEqual(block.order, ["a", "b", "c"])
+
+        created = block.create()
+
+        self.assertIsInstance(created.a, nn.Linear)
+        self.assertIsInstance(created.b, nn.Linear)
+        self.assertIsInstance(created.c, nn.Conv2d)
+        self.assertListEqual(created.order, ["a", "b", "c"])
+
+        built = block.build()
+
+        self.assertIsInstance(built.a, nn.Linear)
+        self.assertIsInstance(built.b, nn.Linear)
+        self.assertIsInstance(built.c, nn.Conv2d)
+        self.assertListEqual(built.order, ["a", "b", "c"])
+
+    def test_append(self):
+        block = SequentialBlock(a=Layer(nn.Linear, 1, 2), b=Layer(nn.Linear, 2, 1))
+        block.append(Layer(nn.Conv2d, 1, 1, 1), name="c")
+
+        self.assertIsInstance(block.a, Layer)
+        self.assertIsInstance(block.b, Layer)
+        self.assertIsInstance(block.c, Layer)
+        self.assertListEqual(block.order, ["a", "b", "c"])
+
+        created = block.create()
+
+        self.assertIsInstance(created.a, nn.Linear)
+        self.assertIsInstance(created.b, nn.Linear)
+        self.assertIsInstance(created.c, nn.Conv2d)
+        self.assertListEqual(created.order, ["a", "b", "c"])
+
+        built = block.build()
+
+        self.assertIsInstance(built.a, nn.Linear)
+        self.assertIsInstance(built.b, nn.Linear)
+        self.assertIsInstance(built.c, nn.Conv2d)
+        self.assertListEqual(built.order, ["a", "b", "c"])
+
+    def test_prepend(self):
+        block = SequentialBlock(a=Layer(nn.Linear, 1, 2), b=Layer(nn.Linear, 2, 1))
+        block.prepend(Layer(nn.Conv2d, 1, 1, 1), name="c")
+
+        self.assertIsInstance(block.a, Layer)
+        self.assertIsInstance(block.b, Layer)
+        self.assertIsInstance(block.c, Layer)
+        self.assertListEqual(block.order, ["c", "a", "b"])
+
+        created = block.create()
+
+        self.assertIsInstance(created.a, nn.Linear)
+        self.assertIsInstance(created.b, nn.Linear)
+        self.assertIsInstance(created.c, nn.Conv2d)
+        self.assertListEqual(created.order, ["c", "a", "b"])
+
+        built = block.build()
+
+        self.assertIsInstance(built.a, nn.Linear)
+        self.assertIsInstance(built.b, nn.Linear)
+        self.assertIsInstance(built.c, nn.Conv2d)
+        self.assertListEqual(built.order, ["c", "a", "b"])
+
+    def test_insert(self):
+        block = SequentialBlock(a=Layer(nn.Linear, 1, 2), b=Layer(nn.Linear, 2, 1))
+        block.insert(Layer(nn.Conv2d, 1, 1, 1), after="a", name="c")
+
+        self.assertIsInstance(block.a, Layer)
+        self.assertIsInstance(block.b, Layer)
+        self.assertIsInstance(block.c, Layer)
+        self.assertListEqual(block.order, ["a", "c", "b"])
+
+        created = block.create()
+
+        self.assertIsInstance(created.a, nn.Linear)
+        self.assertIsInstance(created.b, nn.Linear)
+        self.assertIsInstance(created.c, nn.Conv2d)
+        self.assertListEqual(created.order, ["a", "c", "b"])
+
+        built = block.build()
+
+        self.assertIsInstance(built.a, nn.Linear)
+        self.assertIsInstance(built.b, nn.Linear)
+        self.assertIsInstance(built.c, nn.Conv2d)
+        self.assertListEqual(built.order, ["a", "c", "b"])
+
+    def test_remove(self):
+        block = SequentialBlock(a=Layer(nn.Linear, 1, 2), b=Layer(nn.Linear, 2, 1))
+        block.remove("a")
+
+        self.assertNotIn("a", block.order)
+
+        created = block.create()
+
+        self.assertNotIn("a", created.order)
+
+        built = block.build()
+
+        self.assertNotIn("a", built.order)
+
+    def test_remove_missing_not_ok(self):
+        block = SequentialBlock(a=Layer(nn.Linear, 1, 2), b=Layer(nn.Linear, 2, 1))
+
+        with self.assertRaises(ValueError):
+            block.remove("c")
+
+    def test_remove_missing_ok(self):
+        block = SequentialBlock(a=Layer(nn.Linear, 1, 2), b=Layer(nn.Linear, 2, 1))
+        block.remove("c", allow_missing=True)
+
+        self.assertNotIn("c", block.order)
+
+    def test_append_dropout(self):
+        block = SequentialBlock(a=Layer(nn.Linear, 1, 2), b=Layer(nn.Linear, 2, 1))
+        block.append_dropout(0.5)
+
+        self.assertIsInstance(block.a, Layer)
+        self.assertIsInstance(block.b, Layer)
+        self.assertIsInstance(block.dropout, Layer)
+        self.assertListEqual(block.order, ["a", "b", "dropout"])
+
+        created = block.create()
+
+        self.assertIsInstance(created.a, nn.Linear)
+        self.assertIsInstance(created.b, nn.Linear)
+        self.assertIsInstance(created.dropout, nn.Dropout)
+        self.assertEqual(created.dropout.p, 0.5)
+        self.assertListEqual(created.order, ["a", "b", "dropout"])
+
+        built = block.build()
+
+        self.assertIsInstance(built.a, nn.Linear)
+        self.assertIsInstance(built.b, nn.Linear)
+        self.assertIsInstance(built.dropout, nn.Dropout)
+        self.assertEqual(built.dropout.p, 0.5)
+        self.assertListEqual(built.order, ["a", "b", "dropout"])
+
+    def test_prepend_dropout(self):
+        block = SequentialBlock(a=Layer(nn.Linear, 1, 2), b=Layer(nn.Linear, 2, 1))
+        block.prepend_dropout(0.5)
+
+        self.assertIsInstance(block.a, Layer)
+        self.assertIsInstance(block.b, Layer)
+        self.assertIsInstance(block.dropout, Layer)
+        self.assertListEqual(block.order, ["dropout", "a", "b"])
+
+        created = block.create()
+
+        self.assertIsInstance(created.a, nn.Linear)
+        self.assertIsInstance(created.b, nn.Linear)
+        self.assertIsInstance(created.dropout, nn.Dropout)
+        self.assertEqual(created.dropout.p, 0.5)
+        self.assertListEqual(created.order, ["dropout", "a", "b"])
+
+        built = block.build()
+
+        self.assertIsInstance(built.a, nn.Linear)
+        self.assertIsInstance(built.b, nn.Linear)
+        self.assertIsInstance(built.dropout, nn.Dropout)
+        self.assertEqual(built.dropout.p, 0.5)
+        self.assertListEqual(built.order, ["dropout", "a", "b"])
+
+    def test_insert_dropout(self):
+        block = SequentialBlock(a=Layer(nn.Linear, 1, 2), b=Layer(nn.Linear, 2, 1))
+        block.insert_dropout(0.5, after="a")
+
+        self.assertIsInstance(block.a, Layer)
+        self.assertIsInstance(block.b, Layer)
+        self.assertIsInstance(block.dropout, Layer)
+        self.assertListEqual(block.order, ["a", "dropout", "b"])
+
+        created = block.create()
+
+        self.assertIsInstance(created.a, nn.Linear)
+        self.assertIsInstance(created.b, nn.Linear)
+        self.assertIsInstance(created.dropout, nn.Dropout)
+        self.assertEqual(created.dropout.p, 0.5)
+        self.assertListEqual(created.order, ["a", "dropout", "b"])
+
+        built = block.build()
+
+        self.assertIsInstance(built.a, nn.Linear)
+        self.assertIsInstance(built.b, nn.Linear)
+        self.assertIsInstance(built.dropout, nn.Dropout)
+        self.assertEqual(built.dropout.p, 0.5)
+        self.assertListEqual(built.order, ["a", "dropout", "b"])
+
+    def test_insert_dropout_missing(self):
+        block = SequentialBlock(a=Layer(nn.Linear, 1, 2), b=Layer(nn.Linear, 2, 1))
+
+        with self.assertRaises(ValueError):
+            block.insert_dropout(0.5, after="c")
+
+    def test_set_dropout_append_if_missing(self):
+        block = SequentialBlock(a=Layer(nn.Linear, 1, 2), b=Layer(nn.Linear, 2, 1))
+        block.set_dropout(0.5, on_missing="append")
+
+        self.assertIsInstance(block.a, Layer)
+        self.assertIsInstance(block.b, Layer)
+        self.assertIsInstance(block.dropout, Layer)
+        self.assertListEqual(block.order, ["a", "b", "dropout"])
+
+        created = block.create()
+
+        self.assertIsInstance(created.a, nn.Linear)
+        self.assertIsInstance(created.b, nn.Linear)
+        self.assertIsInstance(created.dropout, nn.Dropout)
+        self.assertEqual(created.dropout.p, 0.5)
+
+        built = block.build()
+
+        self.assertIsInstance(built.a, nn.Linear)
+        self.assertIsInstance(built.b, nn.Linear)
+        self.assertIsInstance(built.dropout, nn.Dropout)
+        self.assertEqual(built.dropout.p, 0.5)
+
+    def test_set_dropout_prepend_if_missing(self):
+        block = SequentialBlock(a=Layer(nn.Linear, 1, 2), b=Layer(nn.Linear, 2, 1))
+        block.set_dropout(0.5, on_missing="prepend")
+
+        self.assertIsInstance(block.a, Layer)
+        self.assertIsInstance(block.b, Layer)
+        self.assertIsInstance(block.dropout, Layer)
+        self.assertListEqual(block.order, ["dropout", "a", "b"])
+
+        created = block.create()
+
+        self.assertIsInstance(created.a, nn.Linear)
+        self.assertIsInstance(created.b, nn.Linear)
+        self.assertIsInstance(created.dropout, nn.Dropout)
+        self.assertEqual(created.dropout.p, 0.5)
+
+        built = block.build()
+
+        self.assertIsInstance(built.a, nn.Linear)
+        self.assertIsInstance(built.b, nn.Linear)
+        self.assertIsInstance(built.dropout, nn.Dropout)
+        self.assertEqual(built.dropout.p, 0.5)
+
+    def test_set_dropout_insert_if_missing(self):
+        block = SequentialBlock(a=Layer(nn.Linear, 1, 2), b=Layer(nn.Linear, 2, 1))
+        block.set_dropout(0.5, on_missing="insert", after="a")
+
+        self.assertIsInstance(block.a, Layer)
+        self.assertIsInstance(block.b, Layer)
+        self.assertIsInstance(block.dropout, Layer)
+        self.assertListEqual(block.order, ["a", "dropout", "b"])
+
+        created = block.create()
+
+        self.assertIsInstance(created.a, nn.Linear)
+        self.assertIsInstance(created.b, nn.Linear)
+        self.assertIsInstance(created.dropout, nn.Dropout)
+        self.assertEqual(created.dropout.p, 0.5)
+
+        built = block.build()
+
+        self.assertIsInstance(built.a, nn.Linear)
+        self.assertIsInstance(built.b, nn.Linear)
+        self.assertIsInstance(built.dropout, nn.Dropout)
+        self.assertEqual(built.dropout.p, 0.5)
+
+    def test_remove_dropout(self):
+        block = SequentialBlock(
+            a=Layer(nn.Linear, 1, 2),
+            b=Layer(nn.Linear, 2, 1),
+            dropout=Layer(nn.Dropout, 0.5),
+        )
+        block.remove_dropout()
+
+        self.assertIsInstance(block.a, Layer)
+        self.assertIsInstance(block.b, Layer)
+        self.assertNotIn("dropout", block.order)
+
+        created = block.create()
+
+        self.assertIsInstance(created.a, nn.Linear)
+        self.assertIsInstance(created.b, nn.Linear)
+        self.assertNotIn("dropout", created.order)
+
+        built = block.build()
+
+        self.assertIsInstance(built.a, nn.Linear)
+        self.assertIsInstance(built.b, nn.Linear)
+        self.assertNotIn("dropout", built.order)
+
+    def test_remove_dropout_missing_not_ok(self):
+        block = SequentialBlock(a=Layer(nn.Linear, 1, 2), b=Layer(nn.Linear, 2, 1))
+
+        with self.assertRaises(ValueError):
+            block.remove_dropout()
+
+    def test_remove_dropout_missing_ok(self):
+        block = SequentialBlock(a=Layer(nn.Linear, 1, 2), b=Layer(nn.Linear, 2, 1))
+        block.remove_dropout(allow_missing=True)
+
+        created = block.create()
+        built = block.build()
+
+        self.assertNotIn("dropout", created.order)
+        self.assertNotIn("dropout", built.order)

--- a/deeplay/tests/test_blocks.py
+++ b/deeplay/tests/test_blocks.py
@@ -409,3 +409,21 @@ class TestSequentalBlock(unittest.TestCase):
 
         self.assertNotIn("dropout", created.order)
         self.assertNotIn("dropout", built.order)
+
+    def test_default_name(self):
+        block = SequentialBlock(a=Layer(nn.Linear, 1, 2), b=Layer(nn.Linear, 2, 1))
+        block.append(Layer(nn.Conv2d, 1, 1, 1))
+
+        self.assertListEqual(block.order, ["a", "b", "conv2d"])
+
+    def test_default_name_not_layer(self):
+        block = SequentialBlock(a=Layer(nn.Linear, 1, 2), b=Layer(nn.Linear, 2, 1))
+        block.append(SequentialBlock())
+
+        self.assertListEqual(block.order, ["a", "b", "sequentialblock"])
+
+    def test_default_name_conflict(self):
+        block = SequentialBlock(a=Layer(nn.Linear, 1, 2), b=Layer(nn.Linear, 2, 1))
+
+        with self.assertRaises(ValueError):
+            block.append(Layer(nn.Conv2d, 1, 1, 1), name="b")

--- a/deeplay/tests/test_selectors.py
+++ b/deeplay/tests/test_selectors.py
@@ -220,11 +220,38 @@ class TestSelectors(unittest.TestCase):
             ],
         )
 
+    def test_selector_isinstance_2(self):
+        selections = self.module["encoder", 0, ...].isinstance(nn.Conv2d).list_names()
+        self.assertListEqual(
+            selections,
+            [
+                ("encoder", "0", "layer"),
+            ],
+        )
+
+    def test_selector_isinstance_3(self):
+        selections = self.module["encoder", 0, ...].isinstance(nn.ReLU).list_names()
+        self.assertListEqual(
+            selections,
+            [
+                ("encoder", "0", "activation"),
+            ],
+        )
+
     def test_selector_hasattr(self):
         selections = self.module["encoder", 0, ...].hasattr("append").list_names()
         self.assertListEqual(
             selections,
             [("encoder", "0")],
+        )
+
+    def test_selector_hasattr_2(self):
+        selections = (
+            self.module["encoder", 0, ...].hasattr("_conv_forward").list_names()
+        )
+        self.assertListEqual(
+            selections,
+            [("encoder", "0", "layer")],
         )
 
     def test_selector_append_all(self):

--- a/deeplay/tests/test_selectors.py
+++ b/deeplay/tests/test_selectors.py
@@ -209,3 +209,36 @@ class TestSelectors(unittest.TestCase):
                 ("decoder", "3", "activation"),
             ],
         )
+
+    def test_selector_isinstance(self):
+        selections = self.module["encoder", 0, ...].isinstance(Layer).list_names()
+        self.assertListEqual(
+            selections,
+            [
+                ("encoder", "0", "layer"),
+                ("encoder", "0", "activation"),
+            ],
+        )
+
+    def test_selector_hasattr(self):
+        selections = self.module["encoder", 0, ...].hasattr("append").list_names()
+        self.assertListEqual(
+            selections,
+            [("encoder", "0")],
+        )
+
+    def test_selector_append_all(self):
+        self.module["encoder", :2, ...].hasattr("append").all.append(
+            Layer(nn.Conv2d, 3, 3, 1, 1), name="conv"
+        )
+        created = self.module.create()
+        self.assertIsInstance(created.encoder[0].conv, nn.Conv2d)
+        self.assertIsInstance(created.encoder[1].conv, nn.Conv2d)
+
+    def test_selector_append_first(self):
+        self.module["encoder", 0, ...].hasattr("append").first.append(
+            Layer(nn.Conv2d, 3, 3, 1, 1), name="conv"
+        )
+        created = self.module.create()
+        self.assertIsInstance(created.encoder[0].conv, nn.Conv2d)
+        self.assertFalse(hasattr(created.encoder[1], "conv"))


### PR DESCRIPTION
Adds block methods and improves Selector flexibility

## Block methods
Adds block methods for adding and removing modules from a sequential block:

```py
block.append(Layer(Linear, 1, 1))
block.append(Layer(Linear, 1, 1), name="fc1")
block.prepend(Layer(Linear, 1, 1))
block.insert(Layer(Linear, 1, 1), after="activation")
block.remove("normalization")
block.append_dropout(0.5)
block.preprend_dropout(0.5)
block.insert_dropout(0.5, after="activation")
block.remove_dropout()
block.set_dropout(0.5, on_missing="append")
```

## Selector methods

Adds `filter` methods: `filter`, `isinstance`, `hasattr`, and the attributes "all" and "first".



```py
Selection.all.some_method() #will apply `some_method` on all selected modules
Selection.first.some_method() #will apply `some_method` on the first selected module
```

some methods, like `configure` and `set_input_map exist on the Selection object, and will
apply either all of first depending on the method. However, this syntax allows you to execute
any method as necessary.

`filter` take `name`, `module` as arguments. `isinstance` and `hasattr` will check `Layer.classtype` if necessary and `include_layer_classtype` is True. So 
```py
isinstance(Layer(Linear), Linear) # True
```

```py
module = ...
module["encoder", ...].isinstance(Layer).configure(...)
module[..., "activation"].isinstance(nn.ReLU).configure(nn.CELU)
module["encoder", ...].hasattr("set_dropout").all.set_dropout(0.1)
module["encoder", ...].filter(lambda name, module: "layer" in name)
``` 