### PR TITLE
 Add set_input/output_map methods to selectors

### DIFF
--- a/deeplay/module.py
+++ b/deeplay/module.py
@@ -1273,6 +1273,14 @@ class Selection(DeeplayModule):
         """Applies `SequentialBlock.set_dropout` to all modules in the selection."""
         return self.all.set_dropout(*args, **kwargs)
 
+    def set_input_map(self, *args, **kwargs):
+        """Applies `DeeplayModule.set_input_map` to all modules in the selection."""
+        return self.all.set_input_map(*args, **kwargs)
+
+    def set_output_map(self, *args, **kwargs):
+        """Applies `DeeplayModule.set_output_map` to all modules in the selection."""
+        return self.all.set_output_map(*args, **kwargs)
+
 
 class _MethodForwarder:
 


### PR DESCRIPTION
This pull request fixes a bug related to a misassignment of input and output mappings when using selectors.