### PR TITLE
fix issue with multi removing too many configurations

### DIFF
--- a/deeplay/blocks/base.py
+++ b/deeplay/blocks/base.py
@@ -47,8 +47,9 @@ class BaseBlock(SequentialBlock):
         # Remove configurations before making new blocks
         tags = self.tags
         for key, vlist in self._user_config.items():
-            if key[:-1] in tags:
-                vlist.clear()
+            if key[:-1] in tags and vlist:
+                if any(isinstance(v.value, DeeplayModule) for v in vlist):
+                    vlist.clear()
 
         def make_new_self():
             args, kwargs = self.get_init_args()

--- a/deeplay/tests/blocks/conv2d/test_conv.py
+++ b/deeplay/tests/blocks/conv2d/test_conv.py
@@ -116,8 +116,23 @@ class TestConv2dBlock(unittest.TestCase):
     #         self.assertEqual(b.layer.stride, (2, 2))
 
     def test_multi_multi(self):
-        block = Conv2dBlock(in_channels=1, out_channels=1).multi(2)
+        block = Conv2dBlock(in_channels=1, out_channels=2).multi(2)
         block.blocks[0].multi(2)
+        block.blocks[1].multi(2)
+        block.build()
+        
+        self.assertEqual(block.blocks[0].blocks[0].layer.in_channels, 1)
+        self.assertEqual(block.blocks[0].blocks[0].layer.out_channels, 2)
+
+        self.assertEqual(block.blocks[0].blocks[1].layer.in_channels, 2)
+        self.assertEqual(block.blocks[0].blocks[1].layer.out_channels, 2)
+
+        self.assertEqual(block.blocks[1].blocks[0].layer.in_channels, 2)
+        self.assertEqual(block.blocks[1].blocks[0].layer.out_channels, 2)
+
+        self.assertEqual(block.blocks[1].blocks[1].layer.in_channels, 2)
+        self.assertEqual(block.blocks[1].blocks[1].layer.out_channels, 2)
+
 
     def test_style_residual(self):
         block = Conv2dBlock(in_channels=1, out_channels=1).style("residual").build()

--- a/deeplay/tests/models/backbones/test_resnet18.py
+++ b/deeplay/tests/models/backbones/test_resnet18.py
@@ -13,6 +13,13 @@ class TestResnet18(unittest.TestCase):
         model = BackboneResnet18(in_channels=3)
         model.build()
 
+    def test_num_params(self):
+        model = BackboneResnet18(in_channels=1)
+        model.build()
+        num_params = sum(p.numel() for p in model.parameters())
+        
+        self.assertEqual(num_params, 11174976)
+
     def test_style_resnet18_input(self):
         block = Conv2dBlock(3, 64).style("resnet18_input").build()
         self.assertEqual(block.layer.kernel_size, (7, 7))


### PR DESCRIPTION
Fixes an issue where `block.multi(n)` would remove configurations. This was introduced to solve a recursion error, however it broke nested calls to `multi`. This PR limits the configurations that are cleared to only include those that may lead to recursion errors.