### PR TITLE
Add order to the cleared configurations

### DIFF
--- a/deeplay/blocks/base.py
+++ b/deeplay/blocks/base.py
@@ -48,8 +48,14 @@ class BaseBlock(SequentialBlock):
         tags = self.tags
         for key, vlist in self._user_config.items():
             if key[:-1] in tags and vlist:
-                if any(isinstance(v.value, DeeplayModule) for v in vlist):
+
+                if (
+                    any(isinstance(v.value, DeeplayModule) for v in vlist)
+                    or key[-1] == "order"
+                ):
                     vlist.clear()
+                else:
+                    print(type(vlist[0].value))
 
         def make_new_self():
             args, kwargs = self.get_init_args()

--- a/deeplay/tests/models/backbones/test_resnet18.py
+++ b/deeplay/tests/models/backbones/test_resnet18.py
@@ -13,11 +13,16 @@ class TestResnet18(unittest.TestCase):
         model = BackboneResnet18(in_channels=3)
         model.build()
 
+    def test_re_init(self):
+        model = BackboneResnet18(in_channels=3)
+        model.__construct__()
+        model.build()
+
     def test_num_params(self):
         model = BackboneResnet18(in_channels=1)
         model.build()
         num_params = sum(p.numel() for p in model.parameters())
-        
+
         self.assertEqual(num_params, 11174976)
 
     def test_style_resnet18_input(self):


### PR DESCRIPTION
Additionally clears any configuration of `order` before doing `multi`.  