### PR TITLE
Refactor Attention UNet

### DIFF
--- a/deeplay/tests/test_attention_unet.py
+++ b/deeplay/tests/test_attention_unet.py
@@ -121,3 +121,24 @@ class TestAttentionUNet(unittest.TestCase):
 
         # Check output shape
         self.assertEqual(output.shape, (2, 1, 64, 64))
+
+    def test_self_attention_heads(self):
+
+        attn_unet = AttentionUNet(
+            in_channels=1,
+            channels=[8, 16, 32],
+            base_channels=[64, 64],
+            channel_attention=[True, True, True],
+            out_channels=1,
+            position_embedding_dim=64,
+            num_attention_heads={"self": 2, "cross": 2},
+        )
+        attn_unet.build()
+
+        # Test on a batch of 2
+        x = torch.rand(2, 1, 64, 64)
+        t = torch.rand(2, 1)
+        output = attn_unet(x, positional_encoding(t, 64), y=None, context=None)
+
+        # Check output shape
+        self.assertEqual(output.shape, (2, 1, 64, 64))


### PR DESCRIPTION
This PR aims to refactor `AttentionUNet`. The following changes are made to make it modularly simple, and produce a much cleaner print statement: 
1. `DoubleConvBlock` is now removed. It was used to implement residual connections at all levels in the UNet. Instead, now they are directly integrated to the `FeatureIntegrationModule` through a couple of `Block` modules.
2. The time step encoding (and class and context embeddings) are now integrated at the middle of the residual connections, rather than at the end.
3. Added a new parameter `num_attention_heads` to control the number of attention heads in self-attention and cross-attention heads. Also added a unittest for this.
4. Removed a warning that was disabling classifier-free guidance for context inputs.

To refactor into deeply style, I see that several styles need to be implemented for `Conv2dBlock`, followed by their integration to `UNet2d`. Some of them exist, but not in the way I want (For example styles, `spatial_self_attention`, and `spatial_cross_attention`). I gave it a quick try, and looks like it is possible to build it with styles but requires extensive testing. I prefer to keep `AttentionUNet` bespoke for now (Unless if you have any suggestions).
