### PR TITLE
Refactor optimizer initialization in active learning strategies

### DIFF
--- a/deeplay/activelearning/strategies/uncertainty.py
+++ b/deeplay/activelearning/strategies/uncertainty.py
@@ -22,9 +22,11 @@ class UncertaintyStrategy(Strategy):
         val_batch_size: int = None,
         test_batch_size: int = None,
         loss=torch.nn.CrossEntropyLoss(),
-        optimizer=Adam(lr=1e-3),
+        optimizer=None,
         **kwargs
     ):
+
+        optimizer = optimizer or Adam(lr=1e-3)
         super().__init__(
             train_pool,
             val_pool,

--- a/deeplay/activelearning/strategies/uniform.py
+++ b/deeplay/activelearning/strategies/uniform.py
@@ -20,9 +20,10 @@ class UniformStrategy(Strategy):
         val_batch_size: int = None,
         test_batch_size: int = None,
         loss=torch.nn.CrossEntropyLoss(),
-        optimizer=Adam(lr=1e-3),
-        **kwargs
+        optimizer=None,
+        **kwargs,
     ):
+        optimizer = optimizer or Adam(lr=1e-3)
         super().__init__(
             train_pool,
             val_pool,
@@ -32,7 +33,7 @@ class UniformStrategy(Strategy):
             test_batch_size,
             loss=loss,
             optimizer=optimizer,
-            **kwargs
+            **kwargs,
         )
         self.classifier = classifier
 


### PR DESCRIPTION
Fixes a bug with where AL strategies would reuse the same optimizer across initializations.