### PR TITLE
set tqdm as default progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Trial notebooks
+trial*.ipynb
+
 # Byte-compiled / optimized / DLL files
 *.pyc
 

--- a/deeplay/callbacks/__init__.py
+++ b/deeplay/callbacks/__init__.py
@@ -1,2 +1,2 @@
-from .progress import RichProgressBar, TQDMProgressBar
 from .history import LogHistory
+from .progress import RichProgressBar, TQDMProgressBar

--- a/deeplay/callbacks/__init__.py
+++ b/deeplay/callbacks/__init__.py
@@ -1,2 +1,2 @@
-from .progress import RichProgressBar
+from .progress import RichProgressBar, TQDMProgressBar
 from .history import LogHistory

--- a/deeplay/callbacks/progress.py
+++ b/deeplay/callbacks/progress.py
@@ -1,48 +1,168 @@
-from weakref import ref
-from lightning.pytorch.callbacks.progress.rich_progress import (
-    RichProgressBar as RPB,
-    RichProgressBarTheme as RPBT,
-)
+"""Enhanced progress bars for compatibility and customization.
 
-from lightning.pytorch.callbacks.progress.tqdm_progress import TQDMProgressBar as TQDM
+This module defines enhanced progress bars for PyTorch Lightning, designed to
+improve compatibility and usability in various environments.
+The `TQDMProgressBar` and `RichProgressBar` classes extend the Lightning
+default implementations and provide safe refresh rate handling for platforms
+like Google Colab and Kaggle, which may crash with small refresh rates.
 
-from lightning.pytorch.utilities.rank_zero import rank_zero_debug
+Key Features
+------------
+- **TQDM Progress Bar with Compatibility Enhancements**
+
+    The `TQDMProgressBar` class extends Lightning's `TQDMProgressBar`,
+    providing a mechanism to adjust refresh rates based on the execution
+    environment. This helps avoid issues caused by small refresh rates on Colab
+    and Kaggle.
+
+- **Rich Progress Bar with Customization Options**
+
+    The `RichProgressBar` class offers a visually appealing progress bar with
+    customizable themes and console options. Similar to the `TQDMProgressBar`,
+    it includes environment-based refresh rate adjustments to enhance
+    stability.
+
+Module Structure
+----------------
+Classes:
+
+- `TQDMProgressBar`: Enhances Lightning TQDM progress bar.
+
+    Automatically modifies the refresh rate if the code is executed on
+    platforms like Colab or Kaggle.
+
+- `RichProgressBar`: Enhances Lightning Rich progress bar.
+
+    Supports configurable themes and console settings, and adjusts refresh
+    rates when needed.
+
+"""
+
+from __future__ import annotations
+
 import os
-import warnings
 
-# from lightning.pytorch.callbacks.progress.tqdm_progress import TQDMProgressBar as TQDM
+from lightning.pytorch.callbacks.progress.rich_progress import (
+    RichProgressBar as LightningRichProgressBar,
+    RichProgressBarTheme as RPBTheme,
+)
+from lightning.pytorch.callbacks.progress.tqdm_progress import (
+    TQDMProgressBar as LightningTQDMProgressBar,
+)
+from lightning.pytorch.utilities.rank_zero import rank_zero_debug
 
 
-class TQDMProgressBar(TQDM):
+class TQDMProgressBar(LightningTQDMProgressBar):
+    """A progress bar for displaying training progress with TQDM.
+
+    This class enhances the standard Lightning TQDMProgressBar by providing
+    environment-specific adjustments to prevent potential crashes on platforms
+    like Colab and Kaggle.
+
+    Parameters
+    ----------
+    refresh_rate : int, optional
+        The refresh rate of the progress bar, by default 1.
+
+    """
+
     def __init__(
-        self,
+        self: TQDMProgressBar,
         refresh_rate: int = 1,
     ):
-        super().__init__(
-            refresh_rate=refresh_rate,
-        )
+        """Initialize the progress bar with a configurable refresh rate.
+
+        Parameters
+        ----------
+        refresh_rate : int, optional
+            The refresh rate of the progress bar, by default 1.
+
+        """
+
+        super().__init__(refresh_rate=refresh_rate)
 
     @staticmethod
     def _resolve_refresh_rate(refresh_rate: int) -> int:
+        """Resolve refresh rate for compatibility with Colab and Kaggle.
+
+        This method adjusts the refresh rate to a safe value to prevent crashes
+        on platforms that are known to have issues with small refresh rates.
+
+        Parameters
+        ----------
+        refresh_rate : int
+            The desired refresh rate of the progress bar.
+
+        Returns
+        -------
+        int
+            The adjusted refresh rate.
+
+        """
+
+        # This should work both for Colab and Kaggle because Kaggle returns a
+        # Colab session.
         if "COLAB_JUPYTER_IP" in os.environ and refresh_rate == 1:
             rank_zero_debug(
-                "Small refresh rates can crash on Colab or Kaggle. Setting refresh_rate to 10.\n"
-                "To manually set the refresh rate, call `trainer.tqdm_progress_bar(refresh_rate=10)`."
+                "Small refresh rates can crash on Colab or Kaggle. "
+                "Setting refresh_rate to 10.\n"
+                "To manually set the refresh rate, "
+                "call `trainer.tqdm_progress_bar(refresh_rate=10)`."
             )
             refresh_rate = 10
 
-        return TQDM._resolve_refresh_rate(refresh_rate)
+        return LightningTQDMProgressBar._resolve_refresh_rate(refresh_rate)
 
 
-class RichProgressBar(RPB):
+class RichProgressBar(LightningRichProgressBar):
+    """A progress bar for displaying training progress with Rich.
+
+    This class enhances the standard Lightning RichProgressBar by supporting
+    customizable themes and console options. It includes an
+    environment-specific adjustment to prevent potential crashes on platforms
+    like Colab and Kaggle.
+
+    Parameters
+    ----------
+    refresh_rate : int, optional
+        The refresh rate of the progress bar, by default 1.
+    leave : bool, optional
+        Whether to leave the progress bar on the screen after completion,
+        by default False.
+    theme : RichProgressBarTheme, optional
+        The theme used for the Rich progress bar,
+        by default `RichProgressBarTheme(metrics_format=".3g")`.
+    console_kwargs : dict, optional
+        Additional keyword arguments for configuring the Rich console,
+        by default None.
+
+    """
 
     def __init__(
-        self,
+        self: RichProgressBar,
         refresh_rate: int = 1,
         leave: bool = False,
-        theme: RPBT = RPBT(metrics_format=".3g"),
+        theme: RPBTheme = RPBTheme(metrics_format=".3g"),
         console_kwargs=None,
     ):
+        """Initialize the Rich progress bar with customizable settings.
+
+        Parameters
+        ----------
+        refresh_rate : int, optional
+            The refresh rate of the progress bar, by default 1.
+        leave : bool, optional
+            Whether to leave the progress bar displayed after completion,
+            by default False.
+        theme : RichProgressBarTheme, optional
+            The theme of the progress bar,
+            by default `RPBTheme(metrics_format=".3g")`.
+        console_kwargs : dict, optional
+            Additional keyword arguments to configure the Rich console,
+            by default None.
+
+        """
+
         super().__init__(
             refresh_rate=refresh_rate,
             leave=leave,
@@ -52,11 +172,32 @@ class RichProgressBar(RPB):
 
     @staticmethod
     def _resolve_refresh_rate(refresh_rate: int) -> int:
+        """Resolve refresh rate for compatibility with Colab and Kaggle.
+
+        This method adjusts the refresh rate to a safe value to prevent crashes
+        on platforms that are known to have issues with small refresh rates.
+
+        Parameters
+        ----------
+        refresh_rate : int
+            The desired refresh rate of the progress bar.
+
+        Returns
+        -------
+        int
+            The adjusted refresh rate.
+
+        """
+
+        # This should work both for Colab and Kaggle because Kaggle returns a
+        # Colab session.
         if "COLAB_JUPYTER_IP" in os.environ and refresh_rate == 1:
             rank_zero_debug(
-                "Small refresh rates can crash on Colab or Kaggle. Setting refresh_rate to 10.\n"
-                "To manually set the refresh rate, call `trainer.rich_progress_bar(refresh_rate=10)`."
+                "Small refresh rates can crash on Colab or Kaggle. "
+                "Setting refresh_rate to 10.\n"
+                "To manually set the refresh rate, "
+                "call `trainer.rich_progress_bar(refresh_rate=10)`."
             )
             refresh_rate = 10
 
-        return TQDM._resolve_refresh_rate(refresh_rate)
+        return LightningTQDMProgressBar._resolve_refresh_rate(refresh_rate)

--- a/deeplay/callbacks/progress.py
+++ b/deeplay/callbacks/progress.py
@@ -36,6 +36,40 @@ Classes:
     Supports configurable themes and console settings, and adjusts refresh
     rates when needed.
 
+Examples
+--------
+This example demosntrate the use of the standard TQDM progress bar:
+
+```python
+import deeplay as dl
+import torch
+
+# Create training dataset.
+num_samples = 10 ** 4
+data = torch.randn(num_samples, 2)
+labels = (data.sum(dim=1) > 0).long()
+
+dataset = torch.utils.data.TensorDataset(data, labels)
+dataloader = dl.DataLoader(dataset, batch_size=16, shuffle=True)
+
+# Create neural network and classifier application.
+mlp = dl.MediumMLP(in_features=2, out_features=2)
+classifier = dl.Classifier(mlp, optimizer=dl.Adam(), num_classes=2).build()
+
+# Train neural network with progress bar.
+tqdm_bar = dl.callbacks.TQDMProgressBar(refresh_rate=100)
+trainer = dl.Trainer(max_epochs=100, callbacks=[tqdm_bar])
+trainer.fit(classifier, dataloader)
+```
+
+Alternatively, you can use the rich progress bar with:
+
+```python
+rich_bar = dl.callbacks.RichProgressBar(refresh_rate=100)
+trainer = dl.Trainer(max_epochs=100, callbacks=[rich_bar])
+trainer.fit(classifier, dataloader)
+```
+
 """
 
 from __future__ import annotations
@@ -63,6 +97,32 @@ class TQDMProgressBar(LightningTQDMProgressBar):
     ----------
     refresh_rate : int, optional
         The refresh rate of the progress bar, by default 1.
+
+    Example
+    -------
+    This example demosntrate the use of the standard TQDM progress bar:
+
+    ```python
+    import deeplay as dl
+    import torch
+
+    # Create training dataset.
+    num_samples = 10 ** 4
+    data = torch.randn(num_samples, 2)
+    labels = (data.sum(dim=1) > 0).long()
+
+    dataset = torch.utils.data.TensorDataset(data, labels)
+    dataloader = dl.DataLoader(dataset, batch_size=16, shuffle=True)
+
+    # Create neural network and classifier application.
+    mlp = dl.MediumMLP(in_features=2, out_features=2)
+    classifier = dl.Classifier(mlp, optimizer=dl.Adam(), num_classes=2).build()
+
+    # Train neural network with progress bar.
+    tqdm_bar = dl.callbacks.TQDMProgressBar(refresh_rate=100)
+    trainer = dl.Trainer(max_epochs=100, callbacks=[tqdm_bar])
+    trainer.fit(classifier, dataloader)
+    ```
 
     """
 
@@ -135,6 +195,32 @@ class RichProgressBar(LightningRichProgressBar):
     console_kwargs : dict, optional
         Additional keyword arguments for configuring the Rich console,
         by default None.
+
+    Example
+    -------
+    This example demosntrate the use of the standard TQDM progress bar:
+
+    ```python
+    import deeplay as dl
+    import torch
+
+    # Create training dataset.
+    num_samples = 10 ** 4
+    data = torch.randn(num_samples, 2)
+    labels = (data.sum(dim=1) > 0).long()
+
+    dataset = torch.utils.data.TensorDataset(data, labels)
+    dataloader = dl.DataLoader(dataset, batch_size=16, shuffle=True)
+
+    # Create neural network and classifier application.
+    mlp = dl.MediumMLP(in_features=2, out_features=2)
+    classifier = dl.Classifier(mlp, optimizer=dl.Adam(), num_classes=2).build()
+
+    # Train neural network with progress bar.
+    rich_bar = dl.callbacks.RichProgressBar(refresh_rate=100)
+    trainer = dl.Trainer(max_epochs=100, callbacks=[rich_bar])
+    trainer.fit(classifier, dataloader)
+    ```
 
     """
 

--- a/deeplay/callbacks/progress.py
+++ b/deeplay/callbacks/progress.py
@@ -3,6 +3,21 @@ from lightning.pytorch.callbacks.progress.rich_progress import (
     RichProgressBarTheme as RPBT,
 )
 
+from lightning.pytorch.callbacks.progress.tqdm_progress import TQDMProgressBar as TQDM
+
+
+# from lightning.pytorch.callbacks.progress.tqdm_progress import TQDMProgressBar as TQDM
+
+
+class TQDMProgressBar(TQDM):
+    def __init__(
+        self,
+        refresh_rate: int = 1,
+    ):
+        super().__init__(
+            refresh_rate=refresh_rate,
+        )
+
 
 class RichProgressBar(RPB):
 

--- a/deeplay/tests/test_trainer.py
+++ b/deeplay/tests/test_trainer.py
@@ -20,7 +20,8 @@ from unittest.mock import patch
 class TestTrainer(unittest.TestCase):
 
     def setUp(self):
-        self._patcher = patch("torch.backends.mps.is_available", return_value=False)
+        self._patcher = patch("torch.backends.mps.is_available",
+                              return_value=False)
         self._mock = self._patcher.start()
 
     def tearDown(self):

--- a/deeplay/tests/test_trainer.py
+++ b/deeplay/tests/test_trainer.py
@@ -2,6 +2,7 @@ from deeplay.trainer import Trainer
 from deeplay.callbacks import LogHistory, RichProgressBar
 from deeplay import Regressor, DataLoader
 from lightning.pytorch.callbacks.progress.tqdm_progress import TQDMProgressBar
+from lightning.pytorch.callbacks.progress.progress_bar import ProgressBar
 import unittest
 import torch.nn as nn
 import lightning as L
@@ -14,8 +15,49 @@ class TestTrainer(unittest.TestCase):
         self.assertIsInstance(trainer, Trainer)
         self.assertIsInstance(trainer.callbacks[0], LogHistory)
         self.assertIsInstance(
-            trainer.callbacks[1], RichProgressBar
+            trainer.callbacks[1], TQDMProgressBar
         )  # should be added by default
+
+    def test_trainer(self):
+        trainer = Trainer(callbacks=[LogHistory()])
+        trainer.disable_progress_bar()
+        self.assertIsInstance(trainer, Trainer)
+        self.assertIsInstance(trainer.callbacks[0], LogHistory)
+
+        has_a_progress_bar = False
+        for callback in trainer.callbacks:
+            if isinstance(callback, ProgressBar):
+                has_a_progress_bar = True
+                break
+        self.assertFalse(has_a_progress_bar)
+
+    def test_trainer_tqdm_progress_bar(self):
+        trainer = Trainer(callbacks=[LogHistory()])
+        trainer.tqdm_progress_bar()
+        self.assertIsInstance(trainer, Trainer)
+        self.assertIsInstance(trainer.callbacks[0], LogHistory)
+
+        num_progress_bars = 0
+        for callback in trainer.callbacks:
+            if isinstance(callback, ProgressBar):
+                num_progress_bars += 1
+                self.assertIsInstance(callback, TQDMProgressBar)
+
+        self.assertEqual(num_progress_bars, 1)
+
+    def test_trainer_rich_progress_bar(self):
+        trainer = Trainer(callbacks=[LogHistory()])
+        trainer.rich_progress_bar()
+        self.assertIsInstance(trainer, Trainer)
+        self.assertIsInstance(trainer.callbacks[0], LogHistory)
+
+        num_progress_bars = 0
+        for callback in trainer.callbacks:
+            if isinstance(callback, ProgressBar):
+                num_progress_bars += 1
+                self.assertIsInstance(callback, RichProgressBar)
+
+        self.assertEqual(num_progress_bars, 1)
 
     def test_trainer_explicit_progress_bar(self):
         trainer = Trainer(callbacks=[LogHistory(), RichProgressBar()])

--- a/deeplay/trainer.py
+++ b/deeplay/trainer.py
@@ -8,7 +8,7 @@ from lightning.pytorch.callbacks.progress.progress_bar import ProgressBar
 from lightning.pytorch.trainer.connectors.callback_connector import _CallbackConnector
 from lightning.pytorch.utilities.types import EVAL_DATALOADERS, TRAIN_DATALOADERS
 
-from deeplay.callbacks import LogHistory, RichProgressBar
+from deeplay.callbacks import LogHistory, RichProgressBar, TQDMProgressBar
 
 
 class _DeeplayCallbackConnector(_CallbackConnector):
@@ -17,7 +17,7 @@ class _DeeplayCallbackConnector(_CallbackConnector):
             c for c in self.trainer.callbacks if isinstance(c, ProgressBar)
         ]
         if enable_progress_bar and not progress_bars:
-            self.trainer.callbacks.append(RichProgressBar())
+            self.trainer.callbacks.append(TQDMProgressBar())
 
         # Not great. Should be in a separate configure method. However, this
         # is arguably more stable to api changes in lightning.
@@ -53,3 +53,35 @@ class Trainer(pl_Trainer):
                 self.callbacks.remove(callback)
                 return
         raise ValueError("History object not found in callbacks")
+
+    def disable_progress_bar(self) -> None:
+        """Disables the progress bar."""
+        for callback in self.callbacks:
+            if isinstance(callback, ProgressBar):
+                self.callbacks.remove(callback)
+                return
+        raise ValueError("Progress bar object not found in callbacks")
+
+    def tqdm_progress_bar(self, refresh_rate: int = 1) -> None:
+        """Enables the tqdm progress bar.
+
+        Parameters
+        ----------
+        refresh_rate : int
+            The refresh rate of the progress bar.
+        """
+        self.disable_progress_bar()
+        self.callbacks.append(TQDMProgressBar(refresh_rate=refresh_rate))
+
+    def rich_progress_bar(self, refresh_rate: int = 1, leave: bool = False) -> None:
+        """Enables the rich progress bar.
+
+        Parameters
+        ----------
+        refresh_rate : int
+            The refresh rate of the progress bar.
+        leave : bool
+            Whether to leave the progress bar after completion.
+        """
+        self.disable_progress_bar()
+        self.callbacks.append(RichProgressBar(refresh_rate=refresh_rate, leave=leave))

--- a/deeplay/trainer.py
+++ b/deeplay/trainer.py
@@ -13,11 +13,6 @@ from deeplay.callbacks import LogHistory, RichProgressBar, TQDMProgressBar
 
 class _DeeplayCallbackConnector(_CallbackConnector):
     def _configure_progress_bar(self, enable_progress_bar: bool = True) -> None:
-        progress_bars = [
-            c for c in self.trainer.callbacks if isinstance(c, ProgressBar)
-        ]
-        if enable_progress_bar and not progress_bars:
-            self.trainer.callbacks.append(TQDMProgressBar())
 
         # Not great. Should be in a separate configure method. However, this
         # is arguably more stable to api changes in lightning.

--- a/deeplay/trainer.py
+++ b/deeplay/trainer.py
@@ -9,10 +9,17 @@ from lightning.pytorch.trainer.connectors.callback_connector import _CallbackCon
 from lightning.pytorch.utilities.types import EVAL_DATALOADERS, TRAIN_DATALOADERS
 
 from deeplay.callbacks import LogHistory, RichProgressBar, TQDMProgressBar
+import os
 
 
 class _DeeplayCallbackConnector(_CallbackConnector):
     def _configure_progress_bar(self, enable_progress_bar: bool = True) -> None:
+
+        progress_bars = [
+            c for c in self.trainer.callbacks if isinstance(c, ProgressBar)
+        ]
+        if enable_progress_bar and not progress_bars:
+            self.trainer.callbacks.append(TQDMProgressBar())
 
         # Not great. Should be in a separate configure method. However, this
         # is arguably more stable to api changes in lightning.

--- a/deeplay/trainer.py
+++ b/deeplay/trainer.py
@@ -1,15 +1,12 @@
-from datetime import timedelta
-from typing import Dict, List, Optional, Union
+from __future__ import annotations
 
-from lightning import Callback, LightningDataModule
 from lightning import Trainer as pl_Trainer
-from lightning.fabric.utilities.types import _PATH
 from lightning.pytorch.callbacks.progress.progress_bar import ProgressBar
-from lightning.pytorch.trainer.connectors.callback_connector import _CallbackConnector
-from lightning.pytorch.utilities.types import EVAL_DATALOADERS, TRAIN_DATALOADERS
+from lightning.pytorch.trainer.connectors.callback_connector import (
+    _CallbackConnector,
+)
 
 from deeplay.callbacks import LogHistory, RichProgressBar, TQDMProgressBar
-import os
 
 
 class _DeeplayCallbackConnector(_CallbackConnector):
@@ -56,23 +53,35 @@ class Trainer(pl_Trainer):
                 return
         raise ValueError("History object not found in callbacks")
 
-    def disable_progress_bar(self) -> None:
-        """Disables the progress bar."""
+    def disable_progress_bar(self: Trainer) -> None:
+        """Disables the progress bar.
+
+        Raises
+        ------
+        ValueError
+            If no progress bar callback is found.
+
+        """
+
         for callback in self.callbacks:
             if isinstance(callback, ProgressBar):
                 self.callbacks.remove(callback)
                 return
+
         raise ValueError("Progress bar object not found in callbacks")
 
-    def tqdm_progress_bar(self, refresh_rate: int = 1) -> None:
-        """Enables the tqdm progress bar.
+    def tqdm_progress_bar(self: Trainer, refresh_rate: int = 1) -> None:
+        """Enables the TQDM progress bar.
 
         Parameters
         ----------
-        refresh_rate : int
-            The refresh rate of the progress bar.
+        refresh_rate : int, optional
+            The refresh rate of the progress bar, by detault 1. 
+
         """
+
         self.disable_progress_bar()
+
         self.callbacks.append(TQDMProgressBar(refresh_rate=refresh_rate))
 
     def rich_progress_bar(self, refresh_rate: int = 1, leave: bool = False) -> None:
@@ -80,10 +89,16 @@ class Trainer(pl_Trainer):
 
         Parameters
         ----------
-        refresh_rate : int
-            The refresh rate of the progress bar.
-        leave : bool
-            Whether to leave the progress bar after completion.
+        refresh_rate : int, optional
+            The refresh rate of the progress bar, by default 1.
+        leave : bool, optional
+            Whether to leave the progress bar after completion,
+            by default False.
+
         """
+
         self.disable_progress_bar()
-        self.callbacks.append(RichProgressBar(refresh_rate=refresh_rate, leave=leave))
+
+        self.callbacks.append(
+            RichProgressBar(refresh_rate=refresh_rate, leave=leave),
+        )


### PR DESCRIPTION
Sets TQDM progress bar as default progress bar since Rich progress bar causes crashes on Colab. It is also faster.

I also implement methods to switch between bars more easily:
```py
trainer = dl.Trainer(max_epochs=10)
trainer.rich_progress_bar(refresh_rate=2)
trainer.tqdm_progress_bar(refresh_rate=2)
trainer.disable_progress_bar()
```