### PR TITLE
Remove import re.T

### DIFF
--- a/deeplay/blocks/base.py
+++ b/deeplay/blocks/base.py
@@ -1,5 +1,4 @@
 from ast import Attribute
-from re import A, T
 from typing import Any, List, Optional, Type, Union, Tuple
 from abc import ABC, abstractmethod
 from warnings import warn

--- a/deeplay/tests/blocks/test_base.py
+++ b/deeplay/tests/blocks/test_base.py
@@ -1,5 +1,4 @@
 from itertools import product
-from re import T
 import unittest
 
 import torch


### PR DESCRIPTION
re.T is not supported in python 3.13++ and actually not in use here, so we can remove it.